### PR TITLE
Remove hash expressions as a supported param

### DIFF
--- a/docs/to-child.md
+++ b/docs/to-child.md
@@ -14,7 +14,7 @@
   @param {String} child-prop The name of the property to set in the 
   component's viewmodel.
 
-  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/hash|can-stache/expressions/call|can-stache/expressions/helper} key An expression whose resulting value is used to set as `childProp`. 
+  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} key An expression whose resulting value is used to set as `childProp`. 
 
 @signature `{$child-prop}="key"`
 

--- a/docs/to-parent.md
+++ b/docs/to-parent.md
@@ -15,7 +15,7 @@ Exports `childProp` in the [can-component::viewModel viewModel] to [can-stache.k
 @param {String} child-prop The name of the property to export from the 
 child components viewmodel. Use `{^this}` or `{^.}` to export the entire viewModel.
 
-@param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/hash|can-stache/expressions/call|can-stache/expressions/helper} key An expression that will be used to set in the parent scope.
+@param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} key An expression that will be used to set in the parent scope.
 
 @signature `{^$child-prop}="key"`
 
@@ -28,7 +28,7 @@ child components viewmodel. Use `{^this}` or `{^.}` to export the entire viewMod
 
   @param {String} child-prop The name of the element's property or attribute to export.
 
-  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/hash|can-stache/expressions/call|can-stache/expressions/helper} key An expression whose resulting value with be used to set in the parent scope.
+  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} key An expression whose resulting value with be used to set in the parent scope.
 
 
 @body

--- a/docs/two-way.md
+++ b/docs/two-way.md
@@ -23,7 +23,7 @@
 
   @param {String} child-prop The name of the property of the viewModel to two-way bind.
 
-  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/hash|can-stache/expressions/call|can-stache/expressions/helper} key A call expression whose value will be used to two-way bind in the parent scope.
+  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} key A call expression whose value will be used to two-way bind in the parent scope.
 
 @signature `{($child-prop)}="key"`
 
@@ -37,7 +37,7 @@
 
   @param {String} child-prop The name of the element's property or attribute to two-way bind.
 
-  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/hash|can-stache/expressions/call|can-stache/expressions/helper} key A call expression whose value will be used to two-way bind in the parent scope.
+  @param {can-stache/expressions/literal|can-stache/expressions/key-lookup|can-stache/expressions/call|can-stache/expressions/helper} key A call expression whose value will be used to two-way bind in the parent scope.
   
 @body
 


### PR DESCRIPTION
To the different binding syntaxes, hash expressions are not supported.

Closes #28
