### PR TITLE
Wrap $element with types.wrapElement

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -313,7 +313,7 @@ require('./converters');
 						"@context": data.scope._context,
 
 						"%element": this,
-						"$element": el,
+						"$element": types.wrapElement(el),
 						"%event": ev,
 						"%viewModel": viewModel,
 						"%scope": data.scope,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "can-compute": "^3.0.0-pre.5",
     "can-event": "^3.0.0-pre.2",
     "can-observation": "^3.0.0-pre.0",
-    "can-util": "^3.0.0-pre.33",
+    "can-util": "^3.0.0-pre.34",
     "can-view-callbacks": "^3.0.0-pre.4",
     "can-view-live": "^3.0.0-pre.1",
     "can-view-model": "^3.0.0-pre.3",

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2324,3 +2324,34 @@ test("Multi-select empty string works(#1263)", function(){
     equal(frag.firstChild.getElementsByTagName("option")[0].selected, false, "The first empty value is not selected");
 
 });
+
+test("$element is wrapped with types.wrapElement", function(){
+	var $ = function(element){
+		this.element = element;
+	};
+
+	var wrapElement = types.wrapElement,
+		unwrapElement = types.unwrapElement;
+
+	types.wrapElement = function(element){
+		return new $(element);
+	};
+
+	types.unwrapElement = function(object){
+		return object.element;
+	};
+
+	var template = stache("<button ($click)='doSomething($element)'>Clicky</button>");
+	var MyMap = DefaultMap.extend({
+		doSomething: function(element){
+			types.wrapElement = wrapElement;
+			types.unwrapElement = unwrapElement;
+
+			ok(element instanceof $);
+		}
+
+	});
+	var button = template(new MyMap()).firstChild;
+
+	canEvent.trigger.call(button, "click");
+});


### PR DESCRIPTION
This uses the new feature of can-util, `types.wrapElement(element)` in
order to wrap an element for a DOM library; can-jquery mostly.

Closes #36
