### PR TITLE
#51 Don't warn when using expressions like id="{{foo}}"

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -730,6 +730,7 @@ require('./converters');
 		}
 	};
 
+	var DOUBLE_CURLY_BRACE_REGEX = /\{\{/g;
 	// ## getBindingInfo
 	// takes a node object like {name, value} and returns
 	// an object with information about that binding.
@@ -756,7 +757,7 @@ require('./converters');
 			//!steal-remove-start
 			// user tried to pass something like id="{foo}", so give them a good warning
 			// Something like id="{{foo}}" is ok, though. (not a binding)
-			if(ignoreAttribute && node.value.replace(/{{/g, "").indexOf("{") > -1) {
+			if(ignoreAttribute && node.value.replace(DOUBLE_CURLY_BRACE_REGEX, "").indexOf("{") > -1) {
 				dev.warn("can-component: looks like you're trying to pass "+attributeName+" as an attribute into a component, "+
 				"but it is not a supported attribute");
 			}

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -755,7 +755,8 @@ require('./converters');
 
 			//!steal-remove-start
 			// user tried to pass something like id="{foo}", so give them a good warning
-			if(ignoreAttribute) {
+			// Something like id="{{foo}}" is ok, though. (not a binding)
+			if(ignoreAttribute && node.value.replace(/{{/g, "").indexOf("{") > -1) {
 				dev.warn("can-component: looks like you're trying to pass "+attributeName+" as an attribute into a component, "+
 				"but it is not a supported attribute");
 			}

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2355,3 +2355,33 @@ test("$element is wrapped with types.wrapElement", function(){
 
 	canEvent.trigger.call(button, "click");
 });
+
+test("No warn on id='{{foo}}' or class='{{bar}}' expressions", function() {
+	var _warn = dev.warn;
+	dev.warn = function() {
+		ok(false, 'dev.warn was called incorrectly');
+		_warn.apply(dev, arguments);
+	};
+	try {
+		expect(2);
+		MockComponent.extend({
+			tag: 'special-attrs',
+			viewModel: {
+				foo: "skippy",
+				baz: "xyzzy"
+			}
+		});
+
+		stache("<special-attrs id='{{foo}}' class='{{baz}}'></div>")({foo: "bar", baz: "quux"});
+
+		dev.warn = function() {
+			ok(true, 'dev.warn was called correctly');
+			_warn.apply(dev, arguments);
+		};
+
+		stache("<special-attrs id='{foo}' class='{baz}'></div>")({foo: "bar", baz: "quux"});
+	} finally {
+		dev.warn = _warn;
+	}
+
+});

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2373,6 +2373,7 @@ test("No warn on id='{{foo}}' or class='{{bar}}' expressions", function() {
 		});
 
 		stache("<special-attrs id='{{foo}}' class='{{baz}}'></div>")({foo: "bar", baz: "quux"});
+		stache("<special-attrs id='foo' class='baz'></div>")({foo: "bar", baz: "quux"});
 
 		dev.warn = function() {
 			ok(true, 'dev.warn was called correctly');


### PR DESCRIPTION
Not sure if this is being too precise, but this will warn about single-brace expressions still.  Double brace usage will not warn.
