### PR TITLE
Check localScope instead of data.scope for matching values on event bindings

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -253,7 +253,6 @@ var attr = require('can-util/dom/attr/attr');
 				onBindElement = true;
 			}
 
-
 			// This is the method that the event will initially trigger. It will look up the method by the string name
 			// passed in the attribute and call it.
 			var handler = function (ev) {
@@ -275,34 +274,7 @@ var attr = require('can-util/dom/attr/attr');
 						expr = new expression.Call(expr, defaultArgs, {} );
 					}
 
-					// We grab the first item and treat it as a method that
-					// we'll call.
-					var scopeData = data.scope.read(expr.methodExpr.key, {
-						isArgument: true
-					});
-
-					// We break out early if the first argument isn't available
-					// anywhere.
-
-					if (!scopeData.value) {
-						scopeData = data.scope.read(expr.methodExpr.key, {
-							isArgument: true
-						});
-
-						//!steal-remove-start
-						dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
-							element: el,
-							scope: data.scope
-						});
-						//!steal-remove-end
-
-						return null;
-					}
-
-
-
 					// make a scope with these things just under
-
 					var localScope = data.scope.add({
 						"@element": el,
 						"@event": ev,
@@ -320,6 +292,27 @@ var attr = require('can-util/dom/attr/attr');
 						notContext: true
 					});
 
+
+					// We grab the first item and treat it as a method that
+					// we'll call.
+					var scopeData = localScope.read(expr.methodExpr.key, {
+						isArgument: true
+					});
+
+					if (!scopeData.value) {
+						scopeData = localScope.read(expr.methodExpr.key, {
+							isArgument: true
+						});
+
+						//!steal-remove-start
+						dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
+							element: el,
+							scope: data.scope
+						});
+						//!steal-remove-end
+
+						return null;
+					}
 
 					var args = expr.args(localScope, null)();
 					return scopeData.value.apply(scopeData.parent, args);

--- a/test/mock-component.js
+++ b/test/mock-component.js
@@ -31,6 +31,7 @@ module.exports = MockComponent = {
 					.add(viewModel, {
 						viewModel: true
 					});
+				domData.set.call(el, "shadowScope", shadowScope);
 				var nodeList = nodeLists.register([], function(){
 					teardownBindings();
 				}, componentTagData.parentNodeList || true, false);


### PR DESCRIPTION
 %viewModel et al. might be included in the event handler (and those things are constructed in a new "local" scope at handling time) so check for their presence _after_ creating them in scope.

Fixes #55 
