### PR TITLE
#50 use tilde syntax to pass computes to child bindings

### DIFF
--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2386,3 +2386,35 @@ test("No warn on id='{{foo}}' or class='{{bar}}' expressions", function() {
 	}
 
 });
+
+test("one-way pass computes to components with ~", function(assert) {
+	expect(7);
+	MockComponent.extend({
+		tag: "foo-bar"
+	});
+
+	var baseVm = new CanMap({foo : "bar"})
+
+	this.fixture.appendChild(stache("<foo-bar {compute}=\"~foo\"></foo-bar>")(baseVm));
+
+	var vm = canViewModel(this.fixture.firstChild)
+
+	ok(vm.attr("compute").isComputed, "Compute returned");
+	equal(vm.attr("compute")(), "bar", "Compute has correct value");
+
+	vm.attr("compute").bind("change", function() {
+		// NB: This gets called twice below, once by
+		//  the parent and once directly.
+		ok(true, "Change handler called");
+	});
+
+	baseVm.attr("foo", "quux");
+	equal(vm.attr("compute")(), "quux", "Compute updates");
+
+	vm.attr("compute")("xyzzy");
+	equal(baseVm.attr("foo"), "quux", "Compute does not update the other direction");
+
+	vm.attr("compute", "notACompute");
+	baseVm.attr("foo", "thud");
+	ok(vm.attr("compute").isComputed, "Back to being a compute");
+});


### PR DESCRIPTION
Example usage:

``` javascript
var fixture = document.getElementById("fixture");
var base = CanMap({ foo: "bar" });
fixture.appendChild(stache('<some-component {compute}="~foo" />')(base));
var vm = canViewModel(fixture.lastChild)
vm.attr("compute"); // -> compute()
vm.attr("compute")(); // -> "bar"
base.attr({"foo":  "quux" });
vm.attr("compute")(); // -> "quux"
```

One thing I'm not certain about is whether I need to fret about unbind/teardown if the child view model sets a different value for the compute.  I didn't see a good way of doing so, but someone else might be better able to comment about memory leak risk for this.
