### PR TITLE
Remove logic from the attributes hookup that is now in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "48.0"

--- a/package.json
+++ b/package.json
@@ -24,39 +24,19 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-stache-bindings",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "donejs"
   ],
   "system": {
     "main": "can-stache-bindings",
-    "configDependencies": [
-      "live-reload"
-    ],
-    "npmIgnore": [
-      "documentjs",
-      "testee",
-      "generator-donejs",
-      "donejs-cli",
-      "steal-tools"
-    ],
     "npmAlgorithm": "flat"
   },
   "dependencies": {
     "can-compute": "^3.0.0-pre.11",
     "can-event": "^3.0.0-pre.2",
     "can-observation": "^3.0.0-pre.8",
-    "can-util": "^3.0.0-pre.34",
+    "can-util": "^3.0.0-pre.44",
     "can-view-callbacks": "^3.0.0-pre.4",
     "can-view-live": "^3.0.0-pre.1",
     "can-view-model": "^3.0.0-pre.3",
@@ -68,7 +48,6 @@
     "can-list": "^3.0.0-pre.1",
     "can-map": "^3.0.0-pre.2",
     "can-view-nodelist": "^3.0.0-pre.2 ",
-    "cssify": "^1.0.2",
     "bit-docs": "0.0.7",
     "done-serve": "^0.2.0",
     "donejs-cli": "^0.9.5",

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -594,58 +594,6 @@ test("can-value select single", function () {
 	equal(map.attr("color"), "green", "updated from input");
 });
 
-test("can-value select multiple with values seperated by a ;", function () {
-	var template = stache(
-		"<select can-value='color' multiple>" +
-		"<option value='red'>Red</option>" +
-		"<option value='green'>Green</option>" +
-		"<option value='ultraviolet'>Ultraviolet</option>" +
-		"</select>");
-
-	var map = new CanMap({
-		color: "red"
-	});
-
-	stop();
-	var frag = template(map);
-
-	var ta = document.getElementById("qunit-fixture");
-	ta.appendChild(frag);
-
-	var inputs = ta.getElementsByTagName("select"),
-		options = inputs[0].getElementsByTagName('option');
-
-	// Wait for Multiselect.set() to be called.
-	setTimeout(function() {
-		equal(inputs[0].value, 'red', "default value set");
-
-		map.attr("color", "green");
-		equal(inputs[0].value, 'green', "alternate value set");
-
-		options[0].selected = true;
-
-		equal(map.attr("color"), "green", "not yet updated from input");
-		canEvent.trigger.call(inputs[0], "change");
-		equal(map.attr("color"), "red;green", "updated from input");
-
-		map.removeAttr("color");
-		equal(inputs[0].value, '', "attribute removed from map");
-
-		options[1].selected = true;
-		canEvent.trigger.call(inputs[0], "change");
-		equal(map.attr("color"), "green", "updated from input");
-
-		map.attr("color", "red;green");
-
-		ok(options[0].selected, 'red option selected from map');
-		ok(options[1].selected, 'green option selected from map');
-		ok(!options[2].selected, 'ultraviolet option NOT selected from map');
-
-		ta.removeChild(ta.firstChild);
-		start();
-	}, 1);
-});
-
 test("can-value select multiple with values cross bound to an array", function () {
 	var template = stache(
 		"<select can-value='colors' multiple>" +
@@ -1556,8 +1504,6 @@ test("checkboxes with {($checked)} bind properly", function () {
 });
 
 test("two-way element empty value (1996)", function(){
-
-
 	var template = stache("<input can-value='age'/>");
 
 	var map = new CanMap();


### PR DESCRIPTION
can-util/dom/attr/attr

A lot of logic was moved into attr, simplifying the attributes hookup
greatly. Closes #59
