### PR TITLE
Adds vdom to the test suite

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -348,9 +348,11 @@ var attr = require('can-util/dom/attr/attr');
 		value: function(el, data) {
 			var propName = "$value",
 				attrValue = removeBrackets(el.getAttribute("can-value")).trim(),
+				nodeName = el.nodeName.toLowerCase(),
+				elType = nodeName === "input" && (el.type || el.getAttribute("type")),
 				getterSetter;
 
-			if (el.nodeName.toLowerCase() === "input" && ( el.type === "checkbox" || el.type === "radio" ) ) {
+			if (nodeName === "input" && (elType === "checkbox" || elType === "radio")) {
 
 				var property = getComputeFrom.scope(el, data.scope, attrValue, {}, true);
 				if (el.type === "checkbox") {
@@ -368,7 +370,7 @@ var attr = require('can-util/dom/attr/attr');
 						}
 					});
 				}
-				else if(el.type === "radio") {
+				else if(elType === "radio") {
 					// radio is two-way bound to if the property value
 					// equals the element value
 
@@ -397,7 +399,7 @@ var attr = require('can-util/dom/attr/attr');
 			}
 
 			var dataBinding = makeDataBinding({
-				name: "{("+propName+"})",
+				name: "{(" + propName + "})",
 				value: attrValue
 			}, el, {
 				templateType: data.templateType,
@@ -408,7 +410,7 @@ var attr = require('can-util/dom/attr/attr');
 				syncChildWithParent: true
 			});
 
-			canEvent.one.call(el, 'removed', function(){
+			canEvent.one.call(el, "removed", function(){
 				dataBinding.onTeardown();
 			});
 

--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
     "can-stache": "^3.0.0-pre.15"
   },
   "devDependencies": {
+    "bit-docs": "0.0.7",
     "can-define": "^0.8.0",
     "can-list": "^3.0.0-pre.1",
     "can-map": "^3.0.0-pre.2",
+    "can-vdom": "0.0.5",
     "can-view-nodelist": "^3.0.0-pre.2 ",
-    "bit-docs": "0.0.7",
     "done-serve": "^0.2.0",
     "donejs-cli": "^0.9.5",
     "generator-donejs": "^0.9.0",


### PR DESCRIPTION
This adds running the tests with can-vdom to the test suite, marking off
only the tests that don't make sense to run in vdom (such as those that
        check for `selectedIndex`.
