### PR TITLE
adding special `%arguments` value for passing the default arguments

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -266,11 +266,13 @@ var attr = require('can-util/dom/attr/attr');
 					// get parsed.
 					var expr = expression.parse(removeBrackets(attrVal),{lookupRule: "method", methodRule: "call"});
 
-					if(!(expr instanceof expression.Call) && !(expr instanceof expression.Helper)) {
+					var defaultArgs = [data.scope._context, el].concat(makeArray(arguments));
 
-						var defaultArgs = [data.scope._context, el].concat(makeArray(arguments)).map(function(data){
+					if(!(expr instanceof expression.Call) && !(expr instanceof expression.Helper)) {
+						defaultArgs = defaultArgs.map(function(data){
 							return new expression.Arg(new expression.Literal(data));
 						});
+
 						expr = new expression.Call(expr, defaultArgs, {} );
 					}
 
@@ -287,7 +289,8 @@ var attr = require('can-util/dom/attr/attr');
 						"%event": ev,
 						"%viewModel": viewModel,
 						"%scope": data.scope,
-						"%context": data.scope._context
+						"%context": data.scope._context,
+						"%arguments": defaultArgs
 					},{
 						notContext: true
 					});

--- a/docs/event.md
+++ b/docs/event.md
@@ -16,11 +16,12 @@ Listens to an event on the element and calls the [can-stache/expressions/call] w
 @param {can-stache/expressions/call} CALL_EXPRESSION A call expression like `method(key)` that is called when the `DOM_EVENT` is fired. The following key values are also supported:
 
  - `%element` - The element the event happened upon.
- - `$element` - The element the event happened upon.
+ - `$element` - The [can-jquery can.$] wrapped element the event happened upon.
  - `%event` - The event object.
  - `%viewModel` - If the element is a [can-component], the component's [can-component::viewModel viewModel].
  - `%context` - The current context.
  - `%scope` - The current [can-view-scope scope].
+ - `%arguments` - The default arguments for the event.
 
 @signature `(VIEW_MODEL_EVENT)='CALL_EXPRESSION'`
 
@@ -37,11 +38,12 @@ be given.
 is fired. The following key values are also supported:
 
  - `%element` - The element the event happened upon.
- - `$element` - The [can.$] wrapped element the event happened upon.
+ - `$element` - The [can-jquery can.$] wrapped element the event happened upon.
  - `%event` - The event object.
  - `%viewModel` - If the element is a [can-component], the component's [can-component::viewModel viewModel].
  - `%context` - The current context.
  - `%scope` - The current [can-view-scope].
+ - `%arguments` - The default arguments for the event.
 
 
 @body

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2441,4 +2441,21 @@ test("special values get called", function(assert) {
 	assert.equal(scope.get("*foo"), "bar", "Reference attribute set");
 });
 
+test("%arguments passes the default arguments", function(){
+	var template = stache("<button ($click)='doSomething(%context, %element, %event, %arguments)'>Default Args</button>");
+
+	var MyMap = DefaultMap.extend({
+		doSomething: function(context, el, ev, args){
+			equal(args[0], context, 'context');
+			equal(args[1], el, 'el');
+			equal(args[2], ev, 'ev');
+		}
+	});
+
+	var frag = template(new MyMap());
+	var button = frag.firstChild;
+
+	canEvent.trigger.call(button, "click");
+});
+
 }


### PR DESCRIPTION
Closes https://github.com/canjs/can-stache-bindings/issues/9.
