### PR TITLE
passing arguments as %arguments, not all of the default helper arguments

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -266,13 +266,11 @@ var attr = require('can-util/dom/attr/attr');
 					// get parsed.
 					var expr = expression.parse(removeBrackets(attrVal),{lookupRule: "method", methodRule: "call"});
 
-					var defaultArgs = [data.scope._context, el].concat(makeArray(arguments));
-
 					if(!(expr instanceof expression.Call) && !(expr instanceof expression.Helper)) {
-						defaultArgs = defaultArgs.map(function(data){
+
+						var defaultArgs = [data.scope._context, el].concat(makeArray(arguments)).map(function(data){
 							return new expression.Arg(new expression.Literal(data));
 						});
-
 						expr = new expression.Call(expr, defaultArgs, {} );
 					}
 
@@ -290,7 +288,7 @@ var attr = require('can-util/dom/attr/attr');
 						"%viewModel": viewModel,
 						"%scope": data.scope,
 						"%context": data.scope._context,
-						"%arguments": defaultArgs
+						"%arguments": arguments
 					},{
 						notContext: true
 					});

--- a/docs/event.md
+++ b/docs/event.md
@@ -21,7 +21,7 @@ Listens to an event on the element and calls the [can-stache/expressions/call] w
  - `%viewModel` - If the element is a [can-component], the component's [can-component::viewModel viewModel].
  - `%context` - The current context.
  - `%scope` - The current [can-view-scope scope].
- - `%arguments` - The default arguments for the event.
+ - `%arguments` - The arguments passed when the event was dispatched/triggered.
 
 @signature `(VIEW_MODEL_EVENT)='CALL_EXPRESSION'`
 
@@ -43,7 +43,7 @@ is fired. The following key values are also supported:
  - `%viewModel` - If the element is a [can-component], the component's [can-component::viewModel viewModel].
  - `%context` - The current context.
  - `%scope` - The current [can-view-scope].
- - `%arguments` - The default arguments for the event.
+ - `%arguments` - The arguments passed when the event was dispatched/triggered.
 
 
 @body

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2439,14 +2439,12 @@ test("special values get called", function(assert) {
 	assert.equal(scope.get("*foo"), "bar", "Reference attribute set");
 });
 
-test("%arguments passes the default arguments", function(){
-	var template = stache("<button ($click)='doSomething(%context, %element, %event, %arguments)'>Default Args</button>");
+test("%arguments gives the event arguments", function(){
+	var template = stache("<button ($click)='doSomething(%event, %arguments)'>Default Args</button>");
 
 	var MyMap = DefaultMap.extend({
-		doSomething: function(context, el, ev, args){
-			equal(args[0], context, 'context');
-			equal(args[1], el, 'el');
-			equal(args[2], ev, 'ev');
+		doSomething: function(ev, args){
+			equal(args[0], ev, 'default arg is ev');
 		}
 	});
 


### PR DESCRIPTION
Closes https://github.com/canjs/can-stache-bindings/issues/9.
