### PR TITLE
adding %arguments test

### DIFF
--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -374,7 +374,25 @@ if (window.jQuery) {
 		ta.appendChild(frag);
 		var p0 = ta.getElementsByTagName("p")[0];
 		canEvent.trigger.call(p0, "myevent", ["myarg1", "myarg2"]);
+	});
 
+	test("extra args to handler can be read using `%arguments`", function () {
+		expect(4);
+		var template = stache("<p can-myevent='handleMyEvent(%arguments)'>{{content}}</p>");
+
+		var frag = template({
+			handleMyEvent: function(args) {
+				ok(true, "handleMyEvent called");
+				ok(args[0] instanceof window.jQuery.Event, "args[0] is a jquery event");
+				equal(args[1], "myarg1", "args[1] is the extra event args");
+				equal(args[2], "myarg2", "args[2] is the extra event args");
+			}
+		});
+
+		var ta = this.fixture;
+		ta.appendChild(frag);
+		var p0 = ta.getElementsByTagName("p")[0];
+		canEvent.trigger.call(p0, "myevent", ["myarg1", "myarg2"]);
 	});
 }
 


### PR DESCRIPTION
Working on https://github.com/canjs/canjs/issues/2527, I found a place to easily add a test for https://github.com/canjs/can-stache-bindings/issues/9 around jQuery.trigger.
