### PR TITLE
Using mutate.appendChild so that <select> is set correctly

### DIFF
--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -1712,9 +1712,7 @@ testIfRealDocument("two way bound select empty string null or undefined value (#
 	});
 	stop();
 	var frag = template(map);
-
-	var ta = this.fixture;
-	ta.appendChild(frag);
+	domMutate.appendChild.call(this.fixture, frag);
 
 	var nullInput = doc.getElementById("null-select");
 	var nullInputOptions = nullInput.getElementsByTagName('option');


### PR DESCRIPTION
In IE9/IE10, <select>'s selectedIndex is set incorrectly when inserted
into the document. This is corrected in can-util by setting the selectedIndex
when the "inserted" event fires. This change makes it so the test uses
mutat.appendChild in order to trigger "inserted" events in browsers that do
not support MutationObserver.
