### PR TITLE
update main entrypoint in package.json so cjs builds work

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "document": "bit-docs",
     "develop": "done-serve --static --develop --port 8080"
   },
-  "main": "dist/cjs/can-stache-bindings",
+  "main": "can-stache-bindings",
   "keywords": [
     "canjs",
     "donejs"


### PR DESCRIPTION
This fixes the main entrypoint so i can use can 3.x in cjs apps without issue.