### PR TITLE
remove @element and other @ special properties

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -276,12 +276,6 @@ var attr = require('can-util/dom/attr/attr');
 
 					// make a scope with these things just under
 					var localScope = data.scope.add({
-						"@element": el,
-						"@event": ev,
-						"@viewModel": viewModel,
-						"@scope": data.scope,
-						"@context": data.scope._context,
-
 						"%element": this,
 						"$element": types.wrapElement(el),
 						"%event": ev,

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -246,7 +246,9 @@ if(typeof doc.getElementsByClassName === 'function') {
 
 	});
 
-	test("can-event special keys", function(){
+	test("can-event special keys", function() {
+		expect( 11 );
+
 		var scope = new CanMap({
 			test: "testval"
 		});
@@ -257,15 +259,20 @@ if(typeof doc.getElementsByClassName === 'function') {
 		});
 		var template = stache("<div>" +
 		"{{#each foodTypes}}" +
-		"<can-event-args-tester class='with-args' can-click='{withArgs @event @element @viewModel @viewModel.test . title content=content}'/>" +
+		"<can-event-args-tester class='with-args' can-click='{withArgs %event %element %viewModel %viewModel.test . title content=content}'/>" +
 		"{{/each}}" +
 		"</div>");
 
 		function withArgs(ev1, el1, compScope, testVal, context, title, hash) {
 			ok(true, "withArgs called");
-			equal(el1.nodeName.toLowerCase(), "can-event-args-tester", "@element is the event's DOM element");
-			equal(ev1.type, "click", "@event is the click event");
-			equal(scope, compScope, "Component scope accessible through @viewModel");
+
+			ok(ev1);
+			ok(el1);
+			ok(compScope);
+
+			equal(el1.nodeName.toLowerCase(), "can-event-args-tester", "%element is the event's DOM element");
+			equal(ev1.type, "click", "%event is the click event");
+			equal(scope, compScope, "Component scope accessible through %viewModel");
 			equal(testVal, scope.attr("test"), "Attributes accessible");
 			equal(context.title, foodTypes[0].title, "Context passed in");
 			equal(title, foodTypes[0].title, "Title passed in");
@@ -282,8 +289,8 @@ if(typeof doc.getElementsByClassName === 'function') {
 		canEvent.trigger.call(p0, "click");
 	});
 
-	test("(event) handlers", 12, function () {
-		//expect(12);
+	test("(event) handlers", function () {
+		expect(15);
 		var ta = this.fixture;
 		var template = stache("<div>" +
 		"{{#each foodTypes}}" +
@@ -330,14 +337,19 @@ if(typeof doc.getElementsByClassName === 'function') {
 
 		template = stache("<div>" +
 		"{{#each foodTypes}}" +
-		"<fancy-event-args-tester class='with-args' ($click)='withArgs @event @element @viewModel @viewModel.test . title content=content'/>" +
+		"<fancy-event-args-tester class='with-args' ($click)='withArgs %event %element %viewModel %viewModel.test . title content=content'/>" +
 		"{{/each}}" +
 		"</div>");
 		function withArgs(ev1, el1, compScope, testVal, context, title, hash) {
 			ok(true, "withArgs called");
-			equal(el1.nodeName.toLowerCase(), "fancy-event-args-tester", "@element is the event's DOM element");
-			equal(ev1.type, "click", "@event is the click event");
-			equal(scope, compScope, "Component scope accessible through @viewModel");
+
+			ok(ev1);
+			ok(el1);
+			ok(compScope);
+
+			equal(el1.nodeName.toLowerCase(), "fancy-event-args-tester", "%element is the event's DOM element");
+			equal(ev1.type, "click", "%event is the click event");
+			equal(scope, compScope, "Component scope accessible through %viewModel");
 			equal(testVal, scope.attr("test"), "Attributes accessible");
 			equal(context.title, foodTypes[0].title, "Context passed in");
 			equal(title, foodTypes[0].title, "Title passed in");


### PR DESCRIPTION
this removes the special properties e.g. @element or @event
use %element or %event instead.

PR aginst `major` for a can-stache-bindings 4.0

close https://github.com/canjs/can-stache/issues/19