### PR TITLE
Removing legacy bindings

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -405,8 +405,7 @@ var attr = require('can-util/dom/attr/attr');
 				scope: data.scope,
 				semaphore: {},
 				initializeValues: true,
-				legacyBindings: true,
-				syncChildWithParent: true
+				legacyBindings: true
 			});
 
 			canEvent.one.call(el, "removed", function(){
@@ -687,7 +686,8 @@ var attr = require('can-util/dom/attr/attr');
 					child: "viewModel",
 					childName: vmName,
 					parentToChild: true,
-					childToParent: true
+					childToParent: true,
+					syncChildWithParent: true
 				};
 			} else {
 				return {
@@ -697,7 +697,8 @@ var attr = require('can-util/dom/attr/attr');
 					child: "viewModel",
 					childName: vmName,
 					parentToChild: true,
-					childToParent: true
+					childToParent: true,
+					syncChildWithParent: true
 				};
 			}
 		}
@@ -717,7 +718,8 @@ var attr = require('can-util/dom/attr/attr');
 				bindingAttributeName: attributeName,
 				childName: childName.substr(1),
 				parentName: attributeValue,
-				initializeValues: true
+				initializeValues: true,
+				syncChildWithParent: twoWay
 			};
 			if(tagName === "select") {
 				bindingInfo.stickyParentToChild = true;
@@ -732,7 +734,8 @@ var attr = require('can-util/dom/attr/attr');
 				bindingAttributeName: attributeName,
 				childName: string.camelize(childName),
 				parentName: attributeValue,
-				initializeValues: true
+				initializeValues: true,
+				syncChildWithParent: twoWay
 			};
 			if(attributeValue.trim().charAt(0) === "~") {
 				bindingInfo.stickyParentToChild = true;
@@ -819,7 +822,7 @@ var attr = require('can-util/dom/attr/attr');
 			if(bindingInfo.childToParent){
 				// setup listening on parent and forwarding to viewModel
 				updateParent = bind.childToParent(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName,
-					bindingData.syncChildWithParent || !!bindingInfo.parentToChild);
+					bindingInfo.syncChildWithParent);
 			}
 			// the child needs to be bound even if
 			else if(bindingInfo.stickyParentToChild) {

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -819,7 +819,7 @@ var attr = require('can-util/dom/attr/attr');
 			if(bindingInfo.childToParent){
 				// setup listening on parent and forwarding to viewModel
 				updateParent = bind.childToParent(el, parentCompute, childCompute, bindingData.semaphore, bindingInfo.bindingAttributeName,
-					bindingData.syncChildWithParent);
+					bindingData.syncChildWithParent || !!bindingInfo.parentToChild);
 			}
 			// the child needs to be bound even if
 			else if(bindingInfo.stickyParentToChild) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-stache-bindings",
-  "version": "3.0.6",
+  "version": "4.0.0-pre.0",
   "description": "Default binding syntaxes for can-stache",
   "homepage": "http://canjs.com",
   "author": {

--- a/test/bindings-define-test.js
+++ b/test/bindings-define-test.js
@@ -288,3 +288,30 @@ if(supportsKeyboardEvents) {
 //		domDispatch.call(input, "focus");
 //	}
 //});
+
+QUnit.test("Two way bindings should be sticky (#122)", function(){
+	var template = stache("<input {($value)}='firstName'/>");
+	var MyMap = define.Constructor({
+		firstName: {
+			set: function(newVal){
+				return newVal.toLowerCase();
+			}
+		}
+	});
+	var map = new MyMap({firstName: "matthew"});
+
+	var frag = template(map);
+
+	var ta = document.getElementById("qunit-fixture");
+	ta.appendChild(frag);
+
+	var input = ta.getElementsByTagName("input")[0];
+	QUnit.equal(input.value, "matthew", "input value set correctly");
+
+	input.value = "MATTHEW";
+
+	canEvent.trigger.call(input, "change");
+
+	QUnit.equal(map.firstName, "matthew", "vm stays the same");
+	QUnit.equal(input.value, "matthew", "input stays the same");
+});

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -9,7 +9,7 @@ var stache = require('can-stache');
 var canEvent = require('can-event');
 var canBatch = require('can-event/batch/batch');
 var viewCallbacks = require('can-view-callbacks');
-var canCompute = require('can-compute')
+var canCompute = require('can-compute');
 var canViewModel = require('can-view-model');
 require('can-util/dom/events/inserted/');
 
@@ -88,7 +88,8 @@ test("attributeNameInfo", function(){
 		childToParent: true,
 		childName: "foo",
 		parentName: "foo",
-		bindingAttributeName: "foo"
+		bindingAttributeName: "foo",
+		syncChildWithParent: true
 	}, "legacy with @");
 
 
@@ -100,7 +101,8 @@ test("attributeNameInfo", function(){
 		childToParent: true,
 		childName: "fooEd",
 		parentName: "bar",
-		bindingAttributeName: "foo-ed"
+		bindingAttributeName: "foo-ed",
+		syncChildWithParent: true
 	},"legacy");
 
 	// ORIGINAL STACHE BEHAVIOR
@@ -112,7 +114,8 @@ test("attributeNameInfo", function(){
 		childToParent: true,
 		childName: "fooEd",
 		parentName: "foo-ed",
-		bindingAttributeName: "foo-ed"
+		bindingAttributeName: "foo-ed",
+		syncChildWithParent: true
 	}, "OG stache attr binding");
 
 	info = stacheBindings.getBindingInfo({name: "foo-ed", value: "{bar}"});
@@ -123,7 +126,8 @@ test("attributeNameInfo", function(){
 		childToParent: true,
 		childName: "fooEd",
 		parentName: "bar",
-		bindingAttributeName: "foo-ed"
+		bindingAttributeName: "foo-ed",
+		syncChildWithParent: true
 	}, "OG stache vm binding");
 
 	// NEW BINDINGS
@@ -138,7 +142,8 @@ test("attributeNameInfo", function(){
 		parentName: "bar",
 		childName: "foo-ed",
 		bindingAttributeName: "{$foo-ed}",
-		initializeValues: true
+		initializeValues: true,
+		syncChildWithParent: false
 	}, "new el binding");
 
 	info = stacheBindings.getBindingInfo({name: "{($foo-ed)}", value: "bar"});
@@ -150,7 +155,8 @@ test("attributeNameInfo", function(){
 		parentName: "bar",
 		childName: "foo-ed",
 		bindingAttributeName: "{($foo-ed)}",
-		initializeValues: true
+		initializeValues: true,
+		syncChildWithParent: true
 	}, "new el binding");
 
 	info = stacheBindings.getBindingInfo({name: "{^$foo-ed}", value: "bar"});
@@ -162,7 +168,8 @@ test("attributeNameInfo", function(){
 		parentName: "bar",
 		childName: "foo-ed",
 		bindingAttributeName: "{^$foo-ed}",
-		initializeValues: true
+		initializeValues: true,
+		syncChildWithParent: false
 	}, "new el binding");
 
 	// vm based
@@ -175,7 +182,8 @@ test("attributeNameInfo", function(){
 		childName: "fooEd",
 		parentName: "bar",
 		bindingAttributeName: "{foo-ed}",
-		initializeValues: true
+		initializeValues: true,
+		syncChildWithParent: false
 	}, "new vm binding");
 
 	info = stacheBindings.getBindingInfo({name: "{(foo-ed)}", value: "bar"});
@@ -187,7 +195,8 @@ test("attributeNameInfo", function(){
 		childName: "fooEd",
 		parentName: "bar",
 		bindingAttributeName: "{(foo-ed)}",
-		initializeValues: true
+		initializeValues: true,
+		syncChildWithParent: true
 	}, "new el binding");
 
 	info = stacheBindings.getBindingInfo({name: "{^foo-ed}", value: "bar"});
@@ -199,7 +208,8 @@ test("attributeNameInfo", function(){
 		childName: "fooEd",
 		parentName: "bar",
 		bindingAttributeName: "{^foo-ed}",
-		initializeValues: true
+		initializeValues: true,
+		syncChildWithParent: false
 	}, "new el binding");
 
 });
@@ -2358,11 +2368,11 @@ test("one-way pass computes to components with ~", function(assert) {
 		tag: "foo-bar"
 	});
 
-	var baseVm = new CanMap({foo : "bar"})
+	var baseVm = new CanMap({foo : "bar"});
 
 	this.fixture.appendChild(stache("<foo-bar {compute}=\"~foo\"></foo-bar>")(baseVm));
 
-	var vm = canViewModel(this.fixture.firstChild)
+	var vm = canViewModel(this.fixture.firstChild);
 
 	ok(vm.attr("compute").isComputed, "Compute returned");
 	equal(vm.attr("compute")(), "bar", "Compute has correct value");


### PR DESCRIPTION
This remove `can-event`, `can-value`, attribute bindings, and support for old mustache bindings.

The thing that is mostly likely to affect people are the lack of attribute bindings.  Previously, the following:

```
<my-component foo="bar"/>
```

This would set `foo` to `"bar"` on the view model.  This won't happen anymore.  