### PR TITLE
Ensure sync of child and parent in two-way bindings

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -159,6 +159,10 @@ var attr = require('can-util/dom/attr/attr');
 				semaphore = {},
 				teardown;
 
+			// If a two-way binding, take extra measure to ensure
+			//  that parent and child sync values properly.
+			var twoWay = bindingsRegExp.exec(attrData.attributeName)[1];
+
 			// Setup binding
 			var dataBinding = makeDataBinding({
 				name: attrData.attributeName,
@@ -170,7 +174,8 @@ var attr = require('can-util/dom/attr/attr');
 				semaphore: semaphore,
 				getViewModel: function(){
 					return viewModel;
-				}
+				},
+				syncChildWithParent: twoWay
 			});
 
 			if(dataBinding.onCompleteBinding) {
@@ -203,7 +208,8 @@ var attr = require('can-util/dom/attr/attr');
 							},
 							// always update the viewModel accordingly.
 							initializeValues: true,
-							nodeList: attrData.nodeList
+							nodeList: attrData.nodeList,
+							syncChildWithParent: twoWay
 						});
 						if(dataBinding) {
 							// The viewModel is created, so call callback immediately.

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2482,5 +2482,5 @@ test("updates happen on changed two-way even when one binding is satisfied", fun
 		canEvent.trigger.call(this.fixture.firstChild, "change");
 		equal(this.fixture.firstChild.value, "king");
 		start();
-	}.bind(this), 10);
+	}.bind(this), 100);
 });

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2429,3 +2429,58 @@ test("%arguments gives the event arguments", function(){
 });
 
 }
+
+test("updates happen on two-way even when one binding is satisfied", function() {
+	var template = stache('<input {($value)}="firstName"/>');
+
+	var ViewModel = DefaultMap.extend({
+		set firstName(newValue) {
+			if(newValue) {
+				return newValue.toLowerCase();
+			}
+		}
+	});
+	var viewModel = new ViewModel({ firstName: "jeffrey" });
+
+	var frag = template(viewModel);
+	domMutate.appendChild.call(this.fixture, frag);
+	equal(this.fixture.firstChild.value, "jeffrey");
+
+	this.fixture.firstChild.value = "JEFFREY";
+	canEvent.trigger.call(this.fixture.firstChild, "change");
+	equal(this.fixture.firstChild.value, "jeffrey");
+});
+
+test("updates happen on changed two-way even when one binding is satisfied", function() {
+	stop();
+	var template = stache('<input {($value)}="{{bindValue}}"/>');
+
+	var ViewModel = DefaultMap.extend({
+		set firstName(newValue) {
+			if(newValue) {
+				return newValue.toLowerCase();
+			}
+		},
+		set lastName(newValue) {
+			if(newValue) {
+				return newValue.toLowerCase();
+			}
+		},
+		bindValue: "string"
+	});
+	var viewModel = new ViewModel({ firstName: "Jeffrey", lastName: "King", bindValue: "firstName" });
+
+	var frag = template(viewModel);
+	domMutate.appendChild.call(this.fixture, frag);
+	equal(this.fixture.firstChild.value, "jeffrey");
+
+	viewModel.bindValue = "lastName";
+	setTimeout(function() {
+		equal(this.fixture.firstChild.value, "king");
+
+		this.fixture.firstChild.value = "KING";
+		canEvent.trigger.call(this.fixture.firstChild, "change");
+		equal(this.fixture.firstChild.value, "king");
+		start();
+	}.bind(this), 10);
+});


### PR DESCRIPTION
...even if parent binding was unchanged due to transformation.

Fixes #122 