### PR TITLE
Warn when doing a "merge binding"

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -1,4 +1,4 @@
-// # can/view/bindings/bindings.js
+// # can-stache-bindings.js
 //
 // This module provides CanJS's default data and event bindings.
 // It's broken up into several parts:
@@ -306,7 +306,7 @@ var attr = require('can-util/dom/attr/attr');
 						});
 
 						//!steal-remove-start
-						dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
+						dev.warn("can-stache-bindings: " + attributeName + " couldn't find method named " + expr.methodExpr.key, {
 							element: el,
 							scope: data.scope
 						});
@@ -433,7 +433,7 @@ var attr = require('can-util/dom/attr/attr');
 
 	//!steal-remove-start
 	function syntaxWarning(el, attrData) {
-		dev.warn('can/view/bindings/bindings.js: mismatched binding syntax - ' + attrData.attributeName);
+		dev.warn('can-stache-bindings: mismatched binding syntax - ' + attrData.attributeName);
 	}
 	viewCallbacks.attr(/^\(.+\}$/, syntaxWarning);
 	viewCallbacks.attr(/^\{.+\)$/, syntaxWarning);
@@ -601,7 +601,7 @@ var attr = require('can-util/dom/attr/attr');
 					else if(types.isMapLike(parentCompute)) {
 						// !steal-dev-start
 						var attrValue = el.getAttribute(attrName);
-						dev.warn("can/view/bindings/bindings.js: Merging " + attrName + " into " + attrValue + " because its parent is non-observable");
+						dev.warn("can-stache-bindings: Merging " + attrName + " into " + attrValue + " because its parent is non-observable");
 						// !steal-dev-end
 						(parentCompute.set || parentCompute.attr).call(
 							parentCompute,

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -464,7 +464,6 @@ var attr = require('can-util/dom/attr/attr');
 						scope.attr(cleanVMName(scopeProp), newVal);
 					};
 				}
-
 			}
 
 		},
@@ -600,7 +599,15 @@ var attr = require('can-util/dom/attr/attr');
 					// is on a plain JS object. This updates the observable to match whatever the
 					// new value is.
 					else if(types.isMapLike(parentCompute)) {
-						parentCompute.attr(newVal, true);
+						// !steal-dev-start
+						var attrValue = el.getAttribute(attrName);
+						dev.warn("can/view/bindings/bindings.js: Merging " + attrName + " into " + attrValue + " because its parent is non-observable");
+						// !steal-dev-end
+						(parentCompute.set || parentCompute.attr).call(
+							parentCompute,
+							newVal.serialize ? newVal.serialize() : newVal,
+							true
+						);
 					}
 				}
 			};

--- a/test/bindings-define-test.js
+++ b/test/bindings-define-test.js
@@ -236,6 +236,18 @@ if (System.env !== 'canjs-test') {
 	});
 }
 
+function makeKeyboardEvent() {
+	try {
+		// IE doesn't support this syntax (Edge does, other evergreen browsers do)
+		var event = new KeyboardEvent("keyup",{key: "Enter"});
+		return event;
+	} catch(e) {
+		event = document.createEvent("KeyboardEvent");
+		event.initKeyboardEvent("keyup", true, false, document.parentWindow, "Enter", 16, "", false, "en-US");
+		return event;
+	}
+}
+
 var supportsKeyboardEvents = (function(){
 	if(typeof KeyboardEvent !== "undefined") {
 		var supports = false;
@@ -243,9 +255,7 @@ var supportsKeyboardEvents = (function(){
 		el.addEventListener("keyup", function(ev){
 			supports = (ev.key === "Enter");
 		});
-		var event = new KeyboardEvent("keyup",{key: "Enter"});
-		el.dispatchEvent(event);
-		return supports;
+		el.dispatchEvent(makeKeyboardEvent());
 	} else {
 		return false;
 	}
@@ -264,7 +274,7 @@ if(supportsKeyboardEvents) {
 		});
 		var input = frag.firstChild;
 
-		var event = new KeyboardEvent("keyup",{key: "Enter"});
+		var event = makeKeyboardEvent();
 		input.dispatchEvent(event);
 	});
 }

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -1601,7 +1601,7 @@ if (System.env.indexOf('production') < 0) {
 	test("warning on a mismatched quote (#1995)", function () {
 		expect(4);
 		var oldlog = dev.warn,
-			message = 'can/view/bindings/bindings.js: mismatched binding syntax - (foo}';
+			message = 'can-stache-bindings: mismatched binding syntax - (foo}';
 
 		dev.warn = function (text) {
 			equal(text, message, 'Got expected message logged.');
@@ -1609,13 +1609,13 @@ if (System.env.indexOf('production') < 0) {
 
 		stache("<div (foo}='bar'/>")();
 
-		message = 'can/view/bindings/bindings.js: mismatched binding syntax - {foo)';
+		message = 'can-stache-bindings: mismatched binding syntax - {foo)';
 		stache("<div {foo)='bar'/>")();
 
-		message = 'can/view/bindings/bindings.js: mismatched binding syntax - {(foo})';
+		message = 'can-stache-bindings: mismatched binding syntax - {(foo})';
 		stache("<div {(foo})='bar'/>")();
 
-		message = 'can/view/bindings/bindings.js: mismatched binding syntax - ({foo})';
+		message = 'can-stache-bindings: mismatched binding syntax - ({foo})';
 		stache("<div ({foo})='bar'/>")();
 
 
@@ -2437,7 +2437,7 @@ if (System.env.indexOf('production') < 0) {
 		var useCanMap = true;
 
 		var oldlog = dev.warn,
-			message = 'can/view/bindings/bindings.js: Merging {(foo)} into bar because its parent is non-observable';
+			message = 'can-stache-bindings: Merging {(foo)} into bar because its parent is non-observable';
 
 		dev.warn = function (text) {
 			equal(text, message, 'Got expected message logged.');


### PR DESCRIPTION
A merge binding happens when the parent side of a two-way binding is an observable property of a plain object.  In this case, the observable's properties are overwritten.  This PR does two things:

* fixes the merge operation by serializing the child object and calling set instead of attr if available;
* throws a warning to the dev console that this is happening (since it's not generally what the user wants)

(There's also a general test fix for IE 9-11)

Addresses #53 