### PR TITLE
Remove deprecated "attr" method

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -462,7 +462,7 @@ var canLog = require('can-util/js/log/log');
 					return parentExpression.value(scope, new Scope.Options({}));
 				} else {
 					return function(newVal){
-						scope.attr(cleanVMName(scopeProp), newVal);
+						scope.set(cleanVMName(scopeProp), newVal);
 					};
 				}
 


### PR DESCRIPTION
Using "attr" method on scope object produce spam in console with deprecation warnings.