### PR TITLE
Upgrade can-compute to 3.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "main": "can-stache-bindings"
   },
   "dependencies": {
-    "can-compute": "^3.0.8",
+    "can-compute": "^3.0.9",
     "can-event": "^3.3.0",
     "can-observation": "^3.0.1",
     "can-stache": "^3.0.22",


### PR DESCRIPTION
can-compute 3.0.9 uses `setImmediate` for some relevant async ops, which should give us more reliable event queueing when testing for things like lifecycle bindings being torn down after a DOM mutation.