### PR TITLE
Fix can-value binding to accept plain-objects

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -366,32 +366,46 @@ var canLog = require('can-util/js/log/log');
 					var trueValue = attr.has(el, "can-true-value") ? el.getAttribute("can-true-value") : true,
 						falseValue = attr.has(el, "can-false-value") ? el.getAttribute("can-false-value") : false;
 
-					getterSetter = compute(function(newValue){
+					getterSetter = compute(function (newValue) {
 						// jshint eqeqeq: false
-						if(arguments.length) {
-							property(newValue ? trueValue : falseValue);
-						}
-						else {
-							return property() == trueValue;
+						var isSet = arguments.length !== 0;
+						var isCompute = property && property.isComputed;
+						if (isCompute) {
+							if (isSet) {
+								property(newValue ? trueValue : falseValue);
+							} else {
+								return property() == trueValue;
+							}
+						} else {
+							if (isSet) {
+								// TODO: https://github.com/canjs/can-stache-bindings/issues/180
+							} else {
+								return property == trueValue;
+							}
 						}
 					});
 				}
 				else if(elType === "radio") {
 					// radio is two-way bound to if the property value
 					// equals the element value
-
-					getterSetter = compute(function(newValue){
+					getterSetter = compute(function (newValue) {
 						// jshint eqeqeq: false
-						if(arguments.length) {
-							if( newValue ) {
+						var isSet = arguments.length !== 0 && newValue;
+						var isCompute = property && property.isComputed;
+						if (isCompute) {
+							if (isSet) {
 								property(el.value);
+							} else {
+								return property() == el.value;
+							}
+						} else {
+							if (isSet) {
+								// TODO: https://github.com/canjs/can-stache-bindings/issues/180
+							} else {
+								return property == el.value;
 							}
 						}
-						else {
-							return property() == el.value;
-						}
 					});
-
 				}
 				propName = "$checked";
 				attrValue = "getterSetter";

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2599,7 +2599,7 @@ test("updates happen on changed two-way even when one binding is satisfied", fun
 				}
 			}
 		},
-		lastName: { 
+		lastName: {
 			set: function(newValue) {
 				if(newValue) {
 					return newValue.toLowerCase();
@@ -2625,4 +2625,36 @@ test("updates happen on changed two-way even when one binding is satisfied", fun
 			start();
 		}.bind(this));
 	}.bind(this));
+});
+
+test('plain data objects should work for checkboxes [can-value] (#161)', function () {
+	var template = stache([
+		'<input type="checkbox" name="status1" value="yes" can-value="status" can-true-value="yes"/>',
+		'<input type="checkbox" name="status2" value="no" can-value="status" can-true-value="no"/>'
+	].join(''));
+	var object = {status: 'yes'};
+
+	var fragment = template(object);
+	domMutate.appendChild.call(this.fixture, fragment);
+	var yesInput = this.fixture.firstChild;
+	var noInput = this.fixture.firstChild.nextSibling;
+
+	equal(yesInput.checked, true, 'yes-checkbox is initially checked');
+	equal(noInput.checked, false, 'no-checkbox is initially not checked');
+});
+
+test('plain data objects should work for radio buttons [can-value] (#161)', function () {
+	var template = stache([
+		'<input type="radio" name="status" value="no" can-value="status"/>',
+		'<input type="radio" name="status" value="yes" can-value="status"/>'
+	].join(''));
+	var object = {status: 'no'};
+
+	var fragment = template(object);
+	domMutate.appendChild.call(this.fixture, fragment);
+	var noInput = this.fixture.firstChild;
+	var yesInput = this.fixture.firstChild.nextSibling;
+
+	equal(noInput.checked, true, 'no-radio is initially checked');
+	equal(yesInput.checked, false, 'yes-radio is initially not checked');
 });


### PR DESCRIPTION
Fixes #161. The goal of this PR is to prevent a `property()` call which blows up when `property` is not a compute. The actual updating of a POJO's value will be addressed by #180.