### PR TITLE
add warnings for non-existing values (fixes #136)

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -832,8 +832,15 @@ var canLog = require('can-util/js/log/log');
 
 		//!steal-remove-start
 		if (parentCompute && parentCompute.isComputed) {
-			if (typeof parentCompute() === "undefined") {
+			if (parentCompute() === undefined) {
 				dev.warn('The parent (' + bindingInfo.parentName + ') you bound to child' +
+					' (' + bindingInfo.childName + ') is not defined in the scope!');
+			}
+		}
+
+		if (childCompute && childCompute.isComputed) {
+			if (childCompute() === undefined) {
+				dev.warn('The child (' + bindingInfo.childName + ') you bound to child' +
 					' (' + bindingInfo.childName + ') is not defined in the scope!');
 			}
 		}

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -961,6 +961,12 @@ var makeDataBinding = function(node, el, bindingData) {
 		bindingInfo.initializeValues = true;
 	}
 
+	//!steal-remove-start
+	if (!domData.get(el, "viewModel")) {
+		dev.warn('This element does not have a viewModel. (Attempting to bind `' + bindingInfo.bindingAttributeName + '="' + bindingInfo.parentName + '"`)');
+	}
+	//!steal-remove-end
+
 	// Get computes for the parent and child binding
 	var parentObservable = getObservableFrom[bindingInfo.parent](
 		el,

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -265,7 +265,7 @@ var behaviors = {
 			if(domData.get.call(el, "preventDataBindings")) {
 				return;
 			}
-			var viewModel = canViewModel(el),
+			var viewModel,
 				semaphore = {},
 				teardown;
 
@@ -287,6 +287,14 @@ var behaviors = {
 				},
 				syncChildWithParent: twoWay
 			});
+
+			//!steal-remove-start
+			if(dataBinding.bindingInfo.child === "viewModel" && !domData.get(el, "viewModel")) {
+				dev.warn('This element does not have a viewModel. (Attempting to bind `' + dataBinding.bindingInfo.bindingAttributeName + '="' + dataBinding.bindingInfo.parentName + '"`)');
+			}
+			//!steal-remove-end
+
+			viewModel = canViewModel(el);
 
 			if(dataBinding.onCompleteBinding) {
 				dataBinding.onCompleteBinding();
@@ -960,12 +968,6 @@ var makeDataBinding = function(node, el, bindingData) {
 	if( bindingData.initializeValues) {
 		bindingInfo.initializeValues = true;
 	}
-
-	//!steal-remove-start
-	if (!domData.get(el, "viewModel")) {
-		dev.warn('This element does not have a viewModel. (Attempting to bind `' + bindingInfo.bindingAttributeName + '="' + bindingInfo.parentName + '"`)');
-	}
-	//!steal-remove-end
 
 	// Get computes for the parent and child binding
 	var parentObservable = getObservableFrom[bindingInfo.parent](

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -830,6 +830,15 @@ var canLog = require('can-util/js/log/log');
 			updateChild,
 			childLifecycle;
 
+		//!steal-remove-start
+		if (parentCompute && parentCompute.isComputed) {
+			if (typeof parentCompute() === "undefined") {
+				dev.warn('The parent (' + bindingInfo.parentName + ') you bound to child' +
+					' (' + bindingInfo.childName + ') is not defined in the scope!');
+			}
+		}
+		//!steal-remove-end
+
 		if(bindingData.nodeList) {
 			if(parentCompute && parentCompute.isComputed){
 				parentCompute.computeInstance.setPrimaryDepth(bindingData.nodeList.nesting+1);

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2561,8 +2561,6 @@ if (System.env.indexOf('production') < 0) {
 	});
 }
 
-}
-
 test("updates happen on two-way even when one binding is satisfied", function() {
 	var template = stache('<input {($value)}="firstName"/>');
 
@@ -2658,3 +2656,19 @@ test('plain data objects should work for radio buttons [can-value] (#161)', func
 	equal(noInput.checked, true, 'no-radio is initially checked');
 	equal(yesInput.checked, false, 'yes-radio is initially not checked');
 });
+
+test("warning when binding to non-existing value (#136)", function() {
+	var oldWarn = dev.warn;
+	dev.warn = function() {
+		ok(true);
+		dev.warn = oldWarn;
+	};
+
+	var template = stache("<div {(target)}='source.bar'/>");
+
+	var map = new CanMap({ source: { foo: "foo" } });
+
+	template(map);
+});
+
+}

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2853,20 +2853,22 @@ test('plain data objects should work for radio buttons [can-value] (#161)', func
 	equal(yesInput.checked, false, 'yes-radio is initially not checked');
 });
 
-test("warning when binding to non-existing value (#136) (#119)", function() {
-	var oldWarn = dev.warn;
-	dev.warn = function() {
-		ok(true);
-	};
+if (System.env.indexOf('production') < 0) {
+	test("warning when binding to non-existing value (#136) (#119)", function() {
+		var oldWarn = dev.warn;
+		dev.warn = function(message) {
+			ok(true, message);
+		};
 
-	var template = stache("<div {(target)}='source.bar'/>");
+		var template = stache("<div {(target)}='source.bar'/>");
 
-	expect(2);
-	var map = new CanMap({ source: { foo: "foo" } });
-	template(map);
+		expect(1);
+		var map = new CanMap({ source: { foo: "foo" } });
+		template(map);
 
-	dev.warn = oldWarn;
-});
+		dev.warn = oldWarn;
+	});
+}
 
 test("changing a scope property calls registered stache helper", function(){
 	expect(1);

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2521,7 +2521,9 @@ if (System.env.indexOf('production') < 0) {
 			message = 'can-stache-bindings: Merging {(foo)} into bar because its parent is non-observable';
 
 		dev.warn = function (text) {
-			equal(text, message, 'Got expected message logged.');
+			if (text === message) {
+				ok(true, 'Got expected message logged.');
+			}
 		};
 
 		delete viewCallbacks._tags["merge-warn-test"];
@@ -2657,18 +2659,19 @@ test('plain data objects should work for radio buttons [can-value] (#161)', func
 	equal(yesInput.checked, false, 'yes-radio is initially not checked');
 });
 
-test("warning when binding to non-existing value (#136)", function() {
+test("warning when binding to non-existing value (#136) (#119)", function() {
 	var oldWarn = dev.warn;
 	dev.warn = function() {
 		ok(true);
-		dev.warn = oldWarn;
 	};
 
 	var template = stache("<div {(target)}='source.bar'/>");
 
+	expect(2);
 	var map = new CanMap({ source: { foo: "foo" } });
-
 	template(map);
+
+	dev.warn = oldWarn;
 });
 
 }

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -2717,7 +2717,9 @@ if (System.env.indexOf('production') < 0) {
 		var thisTest = QUnit.config.current;
 		dev.warn = function(text) {
 			if(QUnit.config.current === thisTest) {
-				equal(text, message, 'Got expected message logged.');
+				if(text === message) {
+					ok(true, 'Got expected message logged.');
+				}
 			}
 		};
 


### PR DESCRIPTION
This may break tests in other repos if they have warning checks. (as my previous add-warnings PR did).

fixes #119
fixes #136