### PR TITLE
Add removed listener for event bindings

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -366,19 +366,31 @@ var stacheHelperCore = require("can-stache/helpers/core");
 					context = canViewModel(el);
 				}
 			}
+
+			// Unbind the event when the attribute is removed from the DOM
+			var attributesHandler = function(ev) {
+				var isEventAttribute = ev.attributeName === attributeName;
+				var isRemoved = !this.getAttribute(attributeName);
+				var isEventAttributeRemoved = isEventAttribute && isRemoved;
+				if (isEventAttributeRemoved) {
+					unbindEvent();
+				}
+			};
+			// Unbind the event when the target is removed from the DOM
+			var removedHandler = function(ev) {
+				unbindEvent();
+			};
+			var unbindEvent = function() {
+				canEvent.off.call(context, event, handler);
+				canEvent.off.call(el, 'attributes', attributesHandler);
+				canEvent.off.call(el, 'removed', removedHandler);
+			};
+
 			// Bind the handler defined above to the element we're currently processing and the event name provided in this
 			// attribute name (can-click="foo")
 			canEvent.on.call(context, event, handler);
-
-			// Create a handler that will unbind itself and the event when the attribute is removed from the DOM
-			var attributesHandler = function(ev) {
-				if(ev.attributeName === attributeName && !this.getAttribute(attributeName)) {
-
-					canEvent.off.call(context, event, handler);
-					canEvent.off.call(el, 'attributes', attributesHandler);
-				}
-			};
 			canEvent.on.call(el, 'attributes', attributesHandler);
+			canEvent.on.call(el, 'removed', removedHandler);
 		},
 		// ### bindings.behaviors.value
 		// Behavior for the deprecated can-value

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -607,6 +607,82 @@ test("two bindings on one element call back the correct method", function () {
 	});
 });
 
+test("event bindings should be removed when the bound element is", function (assert) {
+	// This test checks whether when an element
+	// with an event binding is removed from the
+	// DOM properly cleans up its event binding.
+
+	var template = stache('<div>{{#if isShowing}}<input ($click)="onClick()"><span></span>{{/if}}</div>');
+	var viewModel = new CanMap({
+		isShowing: false,
+		onClick: function () {}
+	});
+	var bindingListenerCount = 0;
+	var hasAddedBindingListener = false;
+	var hasRemovedBindingListener = false;
+
+	// Set the scene before we override domEvents
+	// as we don't care about "click" events before
+	// our input is shown/hidden.
+	var fragment = template(viewModel);
+	domMutate.appendChild.call(this.fixture, fragment);
+
+	// Predicate for relevant events
+	var isInputBindingEvent = function (element, eventName) {
+		return element.nodeName === 'INPUT' && eventName === 'click';
+	};
+
+	// Override domEvents to detect removed handlers
+	var realAddEventListener = domEvents.addEventListener;
+	var realRemoveEventListener = domEvents.removeEventListener;
+	domEvents.addEventListener = function (eventName) {
+		if (isInputBindingEvent(this, eventName)) {
+			bindingListenerCount++;
+			hasAddedBindingListener = true;
+		}
+		return realAddEventListener.apply(this, arguments);
+	};
+	domEvents.removeEventListener = function (eventName) {
+		if (isInputBindingEvent(this, eventName)) {
+			bindingListenerCount--;
+			hasRemovedBindingListener = true;
+		}
+		return realRemoveEventListener.apply(this, arguments);
+	};
+
+	// Add and then remove the input from the DOM
+	// NOTE: the implementation uses "remove" which is asynchronous.
+	viewModel.attr('isShowing', true);
+
+	var andThen = function () {
+		domEvents.removeEventListener.call(span, 'removed', andThen);
+		start();
+
+		// Reset domEvents
+		domEvents.addEventListener = realAddEventListener;
+		domEvents.removeEventListener = realRemoveEventListener;
+
+		// We should have:
+		// - Called add/remove for the event handler at least once
+		// - Called add/remove for the event handler an equal number of times
+		assert.ok(hasAddedBindingListener, 'An event listener should have been added for the binding');
+		assert.ok(hasRemovedBindingListener, 'An event listener should have been removed for the binding');
+
+		var message = bindingListenerCount + ' event listeners were added but not removed';
+		if (removeEventListener < 0) {
+			message = 'Event listeners were removed more than necessary';
+		}
+		assert.equal(bindingListenerCount, 0, message);
+	};
+
+	// We use the also effected span so we
+	// can test the input handlers in isolation.
+	var span = this.fixture.firstChild.lastChild;
+	domEvents.addEventListener.call(span, 'removed', andThen);
+	viewModel.attr('isShowing', false);
+	stop();
+});
+
 test("can-value select remove from DOM", function () {
 	stop();
 	expect(1);


### PR DESCRIPTION
This fixes the memory leak described in this comment: https://github.com/canjs/canjs/issues/3147#issuecomment-301749119. The problem was that event bindings for elements removed from the DOM were not being cleaned up.