### PR TITLE
add bindings-test delay

### DIFF
--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -3011,4 +3011,16 @@ test("call expressions work (#208)", function(){
 
 // Add new tests above this line
 
+// Switching between dom and vdom can cause some tests to fail. This test should
+// always be the last test, to introduce a delay to prevent the failures.
+test("Test Delay", function() {
+	QUnit.stop();
+	expect(0);
+
+	setTimeout(function () {
+		QUnit.start();
+	}, 100);
+
+});
+
 }

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -80,10 +80,17 @@ QUnit.module(name, {
 
 		stop();
 		afterMutation(function() {
-			start();
 			types.DefaultMap = DefaultMap;
 			DOCUMENT(DOC);
 			MUTATION_OBSERVER(MUT_OBS);
+
+			var fixture = document.getElementById("qunit-fixture");
+			while (fixture && fixture.hasChildNodes()) {
+				domData.delete.call(fixture.lastChild);
+				fixture.removeChild(fixture.lastChild);
+			}
+
+			start();
 		});
 	}
 });
@@ -3010,17 +3017,5 @@ test("call expressions work (#208)", function(){
 });
 
 // Add new tests above this line
-
-// Switching between dom and vdom can cause some tests to fail. This test should
-// always be the last test, to introduce a delay to prevent the failures.
-test("Test Delay", function() {
-	QUnit.stop();
-	expect(0);
-
-	setTimeout(function () {
-		QUnit.start();
-	}, 100);
-
-});
 
 }


### PR DESCRIPTION
Though inconsistent, the dom/vdom switching seems to be causing some tests to fail. Adding a short delay as the last test fixes it for me.