### PR TITLE
allows VM bindings to set a context and bypass creating a vm if no bindings

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -82,9 +82,10 @@ var throwOnlyOneTypeOfBindingError = function(){
 	throw new Error("can-stache-bindings - you can not have contextual bindings ( {this}='value' ) and key bindings ( {prop}='value' ) on one element.");
 };
 
-//isSettingOnViewModel: false,
-// if we have binding like {this}="bar"
-// isSettingViewModel: false
+// This function checks if there bindings that are trying
+// to set a property ON the viewModel _conflicting_ with bindings trying to
+// set THE viewModel ITSELF.
+// If there is a conflict, an error is thrown.
 var checkBindingState = function(bindingState, dataBinding) {
 	var isSettingOnViewModel = dataBinding.bindingInfo.parentToChild && dataBinding.bindingInfo.child === "viewModel";
 	if(isSettingOnViewModel) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-stache-bindings",
-  "version": "3.2.0",
+  "version": "3.2.0-pre.0",
   "description": "Default binding syntaxes for can-stache",
   "homepage": "http://canjs.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-stache-bindings",
-  "version": "3.2.0-pre.0",
+  "version": "3.3.0-pre.0",
   "description": "Default binding syntaxes for can-stache",
   "homepage": "http://canjs.com",
   "author": {


### PR DESCRIPTION
This makes it possible for `bindings.viewModel()` to initialize with bar in `{this}="bar"`