### PR TITLE
Update to latest can-stache-key

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "can-view-live": "^3.2.0-pre.0",
     "can-view-model": "^3.4.0-pre.0",
     "can-view-scope": "^3.3.0-pre.3",
-    "can-stache-key": "^0.0.2"
+    "can-stache-key": "0.0.4"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.githubusercontent.com/phillipskevin/75a3626b00dd32709b13132706cb7f30/raw/8514b4aae04888d6d5aff4f577a25816342d95d2/bump-can-stache-key.js**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.