### PR TITLE
encoding attribute before looking for callback

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -982,7 +982,7 @@ var getBindingInfo = function(node, attributeViewModelBindings, templateType, ta
 			//!steal-remove-end
 
 			// if this is handled by another binding or a attribute like `id`.
-			if ( ignoreAttribute || viewCallbacks.attr(attributeName) ) {
+			if ( ignoreAttribute || viewCallbacks.attr( encoder.encode(attributeName) ) ) {
 				return;
 			}
 			var syntaxRight = attributeValue[0] === "{" && last(attributeValue) === "}";

--- a/test/bindings-colon-test.js
+++ b/test/bindings-colon-test.js
@@ -503,4 +503,28 @@ test('can bind to element using on:el:prop', function() {
 	canEvent.trigger.call(element, "prop");
 });
 
+QUnit.test("on:el:click works inside {{#if}} on element with a viewModel (#279)", function() {
+	var map = new SimpleMap({
+	});
+
+	var MySimpleMap = SimpleMap.extend({
+		show: true,
+		method: function(){
+			ok(true, "method called");
+		}
+	});
+	var parent = new MySimpleMap();
+
+	MockComponent.extend({
+		tag: "view-model-able",
+		viewModel: map
+	});
+
+	var template = stache("<view-model-able {{#if show}} on:el:click='method()' {{/if}} />");
+
+	var frag = template(parent);
+	var el = frag.firstChild;
+	canEvent.trigger.call(el, "click");
+});
+
 }

--- a/test/bindings-define-test.js
+++ b/test/bindings-define-test.js
@@ -441,3 +441,26 @@ test(".viewModel() can bypass dynamic bindings", function(){
 	var template = stache('<export-this/>');
 	template(myMap);
 });
+
+QUnit.test("($click) works inside {{#if}} on element with a viewModel (#279)", function() {
+	var ViewModel = DefineMap.extend({});
+
+	MockComponent.extend({
+		tag: 'view-model-able',
+		viewModel: ViewModel
+	});
+
+	var template = stache("<view-model-able {{#if show}} ($click)='method()' {{/if}} />");
+
+	var Parent = DefineMap.extend({
+		show: { value: true },
+		method: function() {
+			QUnit.ok(true, '($click) worked');
+		}
+	});
+	var parent = new Parent();
+
+	var frag = template(parent);
+	var el = frag.firstChild;
+	canEvent.trigger.call(el, "click");
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-stache-bindings/issues/279.

Without this, `{{#if show}} ($click)='method()' {{/if}}` will not correctly see a callback for `($click)` when `show` changes.