### PR TITLE
Checked for endsWith returning a -1

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -895,7 +895,8 @@ var startsWith = String.prototype.startsWith || function(text){
 	return this.indexOf(text) === 0;
 };
 var endsWith = String.prototype.endsWith || function(text){
-	return this.lastIndexOf(text) === (this.length - text.length);
+	var lastIndex = this.lastIndexOf(text);
+	return lastIndex !== -1 && lastIndex === (this.length - text.length);
 };
 // Regular expressions for getBindingInfo
 var bindingsRegExp = /\{(\()?(\^)?([^\}\)]+)\)?\}/,


### PR DESCRIPTION
Checked to make sure endsWith does not return a -1 for the search value not being found before comparing lengths of the text and pattern to see if it is really at the end.

ex. `"{^.}".lastIndexOf(":from") === "{^.}".length - ":from".length` is true even though `:from` is not present.

For https://github.com/canjs/canjs/issues/3482