### PR TITLE
fixing events that start with `to`, `from`, or `bind`

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -659,9 +659,16 @@ viewCallbacks.attr(/^(:lp:)(:lb:).+(:rb:)(:rp:)$/, syntaxWarning);
 
 // `{}="bar"` data bindings.
 viewCallbacks.attr(/^(:lb:)[(:c:)\w-]+(:rb:)$/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:to/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:from/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:bind/, behaviors.data);
+// value:to="bar" data bindings
+// these are separate so that they only capture at the end
+// to avoid (toggle)="bar" which is encoded as :lp:toggle:rp:="bar"
+viewCallbacks.attr(/[\w\.:]+:to$/, behaviors.data);
+viewCallbacks.attr(/[\w\.:]+:from$/, behaviors.data);
+viewCallbacks.attr(/[\w\.:]+:bind$/, behaviors.data);
+// value:to:on:input="bar" data bindings
+viewCallbacks.attr(/[\w\.:]+:to:on:[\w\.:]+/, behaviors.data);
+viewCallbacks.attr(/[\w\.:]+:from:on:[\w\.:]+/, behaviors.data);
+viewCallbacks.attr(/[\w\.:]+:bind:on:[\w\.:]+/, behaviors.data);
 
 // `*ref-export` shorthand.
 viewCallbacks.attr(/\*[\w\.\-_]+/, behaviors.reference);

--- a/test/bindings-define-test.js
+++ b/test/bindings-define-test.js
@@ -464,3 +464,41 @@ QUnit.test("($click) works inside {{#if}} on element with a viewModel (#279)", f
 	var el = frag.firstChild;
 	canEvent.trigger.call(el, "click");
 });
+
+QUnit.test("events starting with `to`, `from`, and `bind` work (#285)", function() {
+	expect(3);
+	var ViewModel = DefineMap.extend({
+		toevent: '1',
+		fromevent: '1',
+		bindevent: '1',
+	});
+
+	MockComponent.extend({
+		tag: 'view-model-able',
+		viewModel: ViewModel
+	});
+
+	var template = stache("<view-model-able (toevent)='toMethod()' (fromevent)='fromMethod()' (bindevent)='bindMethod()' />");
+
+	var Parent = DefineMap.extend({
+		toMethod: function() {
+			QUnit.ok(true, '(toevent) worked');
+		},
+		fromMethod: function() {
+			QUnit.ok(true, '(fromevent) worked');
+		},
+		bindMethod: function() {
+			QUnit.ok(true, '(bindevent) worked');
+		}
+	});
+	var parent = new Parent();
+
+	var frag = template(parent);
+	var el = frag.firstChild;
+
+	var vm = canViewModel(el);
+
+	vm.toevent = '2';
+	vm.fromevent = '2';
+	vm.bindevent = '2';
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-stache-bindings/issues/285.