### PR TITLE
Set minimum required can-stache dependency to 3.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "can-observation": "^3.3.1",
     "can-reflect": "^1.2.1",
     "can-simple-map": "^3.3.0",
-    "can-stache": "^3.4.0",
+    "can-stache": "^3.7.1",
     "can-stache-key": "0.1.0",
     "can-symbol": "^1.0.0",
     "can-types": "^1.1.0",


### PR DESCRIPTION
3.7.1 fixes the dotted property issue (using references like `{{foo['bar.baz']}}`), so users should be using that as the minimum version to avoid those issues (also to pass the tests with #290).