### PR TITLE
Sets initialize values to false if there is an event binding

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -1015,15 +1015,17 @@ var getBindingInfo = function(node, attributeViewModelBindings, templateType, ta
 		});
 
 		if(dataBindingName) {
+			var childEventName = getEventName(result);
+			var initializeValues = childEventName ? false : true;
 			return assign({
 				parent: scopeBindingStr,
 				child: getChildBindingStr(result.tokens, favorViewModel),
 				// the child is going to be the token before the special location
 				childName: result.tokens[specialIndex-1],
-				childEvent: getEventName(result),
+				childEvent: childEventName,
 				bindingAttributeName: attributeName,
 				parentName: attributeValue,
-				initializeValues: true
+				initializeValues: initializeValues
 			}, bindingRules[dataBindingName]);
 		}
 		// END: check new binding syntaxes ======

--- a/test/bindings-colon-test.js
+++ b/test/bindings-colon-test.js
@@ -737,7 +737,7 @@ QUnit.test("getBindingInfo works for value:to:on:click (#269)", function(){
 		childName: "value",
 		parentName: "bar",
 		bindingAttributeName: "value:to:on:click",
-		initializeValues: true,
+		initializeValues: false,
 		syncChildWithParent: false
 	}, "new vm binding");
 
@@ -899,6 +899,37 @@ QUnit.test('el:prop:to/:from/:bind work (#280)', function() {
 
 	scope.attr('scope3', 'scope7');
 	equal(inputBind.value, 'scope7', 'el:value:bind - attribute updated when scope changed');
+});
+
+QUnit.test("on:input:value:to works (#289)", function() {
+	var scope = new SimpleMap({
+		myProp: ""
+	});
+
+	var renderer = stache("<input type='text' value='hai' on:input:value:to='myProp' />");
+	
+	var view = renderer(scope);
+
+	var ta = this.fixture;
+	ta.appendChild(view);
+
+	var inputTo = ta.getElementsByTagName('input')[0];
+
+	inputTo.value = 'wurld';
+	canEvent.trigger.call(inputTo, 'input');
+
+	equal(scope.get('myProp'), 'wurld', "Got the value on the scope");
+
+});
+
+QUnit.test("on:input:value:to does not initialize values (#289)", function() {
+	try {
+		stache("<input on:input:value:to='*editing.licensePlate'/>")();
+		ok(true, "renderer was made without error");
+	}
+	catch(e) {
+		ok(false, e.message);
+	}
 });
 
 }


### PR DESCRIPTION
If there is an event binding as well as a data binding we don't want to initialize values. The data binding should only occur when the event occurs.

Closes #289 

In looking into this issue another bug was found that is described in https://github.com/canjs/can-stache-bindings/issues/298