### PR TITLE
Issue warning messages when using old braced binding syntax; deprecate in docs

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -111,7 +111,7 @@ function setPriority(observable, priority){
 }
 
 var throwOnlyOneTypeOfBindingError = function(){
-	throw new Error("can-stache-bindings - you can not have contextual bindings ( {this}='value' ) and key bindings ( {prop}='value' ) on one element.");
+	throw new Error("can-stache-bindings - you can not have contextual bindings ( this:from='value' ) and key bindings ( prop:from='value' ) on one element.");
 };
 
 // This function checks if there bindings that are trying
@@ -439,6 +439,22 @@ var behaviors = {
 				}
 			} else {
 				event = removeBrackets(attributeName, '(', ')');
+
+				//!steal-dev-start
+				// Warn about using old style (paren-delimited) event binding syntax.  We've moved to using on:
+				dev.warn(
+					"can-stache-bindings: the event binding format (" +
+					event +
+					") is deprecated. Use on:" +
+					string.camelize(
+						event[0] === "$" ?
+						event.slice(1) :
+						event.split(" ").reverse().filter(function(s) { return s; }).join(":by:")
+						) +
+					" instead"
+				);
+				//!steal-dev-end
+
 				if(event.charAt(0) === "$") {
 					event = event.substr(1);
 					bindingContext = el;
@@ -627,7 +643,7 @@ var behaviors = {
 			}
 
 			var dataBinding = makeDataBinding({
-				name: "{(" + propName + "})",
+				name: "{(" + propName + ")}",
 				value: attrValue
 			}, el, {
 				templateType: data.templateType,
@@ -1005,6 +1021,8 @@ var getBindingInfo = function(node, attributeViewModelBindings, templateType, ta
 			dataBindingName,
 			specialIndex;
 
+
+
 		// check if there's a match of a binding name with at least a value before it
 		bindingNames.forEach(function(name){
 			if(result.special[name] !== undefined && result.special[name] > 0) {
@@ -1081,6 +1099,22 @@ var getBindingInfo = function(node, attributeViewModelBindings, templateType, ta
 			parentToChild = twoWay || !childToParent;
 
 		childName = matches[3];
+		//!steal-dev-start
+		// Warn about using old style (brace-delimited) binding syntax.  We've moved to using
+		// :bind, :from, and :to instead.
+		var newLookup = {
+			"^": ":to",
+			"(": ":bind"
+		};
+		dev.warn(
+			"can-stache-bindings: the data binding format " +
+			attributeName +
+			" is deprecated. Use " +
+			string.camelize(matches[3][0] === "$" ? matches[3].slice(1) : matches[3]) +
+			(newLookup[attributeName.charAt(1)] || ":from") +
+			" instead"
+		);
+		//!steal-dev-end
 		var isDOM = childName.charAt(0) === "$";
 		if(isDOM) {
 			bindingInfo = {

--- a/docs/legacy/bindings.md
+++ b/docs/legacy/bindings.md
@@ -1,10 +1,10 @@
-@module legacy\ \{\(\$\^\)\}\ bindings can-stache-bindings Legacy Syntaxes
-@group can-stache-bindings.legacy-syntaxes Legacy Syntaxes
+@module deprecated\ \{\(\$\^\)\}\ bindings can-stache-bindings Deprecated Syntaxes
+@group can-stache-bindings.legacy-syntaxes Deprecated Syntaxes
 @parent can-stache-bindings.syntaxes 5
 
 Provides template event, one-way bindings, and two-way bindings.
 
-> Note: this syntax will be deprecated in an upcoming release and you should use the [can-stache-bindings new syntax] instead
+> Note: This syntax is **deprecated** and you should use the [can-stache-bindings new syntax] instead
 
 @body
 

--- a/test/bindings-define-test.js
+++ b/test/bindings-define-test.js
@@ -506,14 +506,14 @@ test("Will not accept more than one data binding if this is bound", function() {
 	try {
 		template(myMap);
 	} catch (error) {
-		QUnit.equal(error.message, "can-stache-bindings - you can not have contextual bindings ( {this}='value' ) and key bindings ( {prop}='value' ) on one element.", "Succesfully errored");
+		QUnit.equal(error.message, "can-stache-bindings - you can not have contextual bindings ( this:from='value' ) and key bindings ( prop:from='value' ) on one element.", "Succesfully errored");
 	}
 
 	template = stache('<export-this {foo}="bar" {this}="value" />');
 	try {
 		template(myMap);
 	} catch (error) {
-		QUnit.equal(error.message, "can-stache-bindings - you can not have contextual bindings ( {this}='value' ) and key bindings ( {prop}='value' ) on one element.", "Succesfully errored");
+		QUnit.equal(error.message, "can-stache-bindings - you can not have contextual bindings ( this:from='value' ) and key bindings ( prop:from='value' ) on one element.", "Succesfully errored");
 	}
 });
 


### PR DESCRIPTION
Fixes #294.