### PR TITLE
Add tests for issue #134

### DIFF
--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -62,7 +62,7 @@ var isRealDocument = function(){
 
 QUnit.module(name, {
 	setup: function() {
-		
+
 		globals.setKeyValue('document', doc);
 		if(!enableMO){
 			globals.setKeyValue('MutationObserver', null);
@@ -85,7 +85,7 @@ QUnit.module(name, {
 		stop();
 		afterMutation(function() {
 			types.DefaultMap = DefaultMap;
-			
+
 			globals.deleteKeyValue('document');
 			globals.deleteKeyValue('MutationObserver');
 
@@ -3094,6 +3094,32 @@ if(System.env.indexOf("production") < 0) {
 		dev.warn = oldWarn;
 	});
 }
+
+QUnit.test("legacy events should bind when using a plain object", function () {
+	var flip = false;
+	var template = stache("<div {{#if test}}($foo)=\"log()\"{{/if}}>Test</div>");
+
+	var frag = template({
+		log: function() {flip = true;},
+		test: true
+	});
+
+	canEvent.trigger.call(frag.firstChild, 'foo')
+	QUnit.ok(flip, "Plain object method successfully called");
+});
+
+QUnit.test("events should bind when using a plain object", function () {
+	var flip = false;
+	var template = stache("<div {{#if test}}on:foo=\"log()\"{{/if}}>Test</div>");
+
+	var frag = template({
+		log: function() {flip = true;},
+		test: true
+	});
+
+	canEvent.trigger.call(frag.firstChild, 'foo')
+	QUnit.ok(flip, "Plain object method successfully called");
+});
 
 // Add new tests above this line
 

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -3104,7 +3104,7 @@ QUnit.test("legacy events should bind when using a plain object", function () {
 		test: true
 	});
 
-	canEvent.trigger.call(frag.firstChild, 'foo')
+	canEvent.trigger.call(frag.firstChild, 'foo');
 	QUnit.ok(flip, "Plain object method successfully called");
 });
 
@@ -3117,7 +3117,7 @@ QUnit.test("events should bind when using a plain object", function () {
 		test: true
 	});
 
-	canEvent.trigger.call(frag.firstChild, 'foo')
+	canEvent.trigger.call(frag.firstChild, 'foo');
 	QUnit.ok(flip, "Plain object method successfully called");
 });
 


### PR DESCRIPTION
Tests explicitly check that handlers are called for events added to a node using a plain object instead of something like a DefineMap.

- test/bindings-test.js Added tests