### PR TITLE
deprecating reference shorthand

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -333,11 +333,16 @@ var behaviors = {
 				canLog.warn("*reference attributes can only export the view model.");
 			}
 
+
 			var name = string.camelize( attrData.attributeName.substr(1).toLowerCase() );
+
+			//!steal-remove-start
+			dev.warn(attrData.attributeName + ' shorthand is deprecated. Use this:to="' + name + '" instead.');
+			//!steal-remove-end
 
 			var viewModel = canViewModel(el);
 			var refs = attrData.scope.getRefs();
-			canReflect.setKeyValue(refs._context, "*" + name, viewModel);
+			canReflect.setKeyValue(refs._context, "scope.vars." + name, viewModel);
 		},
 		// ### bindings.behaviors.event
 		// The following section contains code for implementing the can-EVENT attribute.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,6 +3,8 @@
 
 @description Export a viewModel into a template's references scope.
 
+@deprecated {4.0} This syntax is deprecated in favor of [can-stache-bindings.toParent `this:to="refProp"`]
+
 @signature `*ref-prop`
 
   A shorthand for exporting an element’s viewModel to the reference scope.

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -3062,6 +3062,18 @@ QUnit.test("events should bind when using a plain object", function () {
 	QUnit.ok(flip, "Plain object method successfully called");
 });
 
+testHelpers.dev.devOnlyTest("warn when using reference shorthand", function() {
+	MockComponent.extend({
+		tag: 'reference-export'
+	});
+
+	var template = stache("<reference-export *reference-export/>");
+
+	var teardown = testHelpers.dev.willWarn('*reference-export shorthand is deprecated. Use this:to="referenceExport" instead.');
+	template({});
+	QUnit.equal(teardown(), 1, 'warning shown');
+});
+
 // Add new tests above this line
 
 }


### PR DESCRIPTION
closes https://github.com/canjs/can-stache-bindings/issues/327.