### PR TITLE
Dedupe dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "can-stache": "^4.0.0-pre.1",
     "can-stache-key": "^1.0.0-pre.9",
     "can-symbol": "^1.0.0",
-    "can-test-helpers": "^1.1.0",
     "can-util": "^3.9.0",
     "can-view-callbacks": "^4.0.0-pre.1",
     "can-view-live": "^4.0.0-pre.12",
@@ -53,7 +52,6 @@
   },
   "devDependencies": {
     "can-define": "^2.0.0-pre.1",
-    "can-queues": "<2.0.0",
     "can-test-helpers": "^1.1.0",
     "can-vdom": "^3.1.0",
     "can-view-nodelist": "^3.1.0",


### PR DESCRIPTION
- Leave can-test-helpers as a devDependency
- Leave can-queues as a regular dependency