### PR TITLE
using a Set to track the handlers added/removed for data behavior bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
+    "can-cid": "^1.1.2",
     "can-define": "^1.3.0",
     "can-list": "^3.2.0",
     "can-map": "^3.3.1",


### PR DESCRIPTION
Back-porting change from `major` to fix issue with this test failing in `can-jquery` suite.