### PR TITLE
Update the reference scope warning to suggest the right replacement code

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -349,7 +349,7 @@ var behaviors = {
 			var name = string.camelize( attrData.attributeName.substr(1).toLowerCase() );
 
 			//!steal-remove-start
-			dev.warn(attrData.attributeName + ' shorthand is deprecated. Use this:to="' + name + '" instead.');
+			dev.warn(attrData.attributeName + ' shorthand is deprecated. Use this:to="scope.vars.' + name + '" instead.');
 			//!steal-remove-end
 
 			var viewModel = canViewModel(el);

--- a/docs/legacy/bindings.md
+++ b/docs/legacy/bindings.md
@@ -1,5 +1,4 @@
-@module deprecated\ \{\(\$\^\)\}\ bindings Deprecated Syntaxes
-@group can-stache-bindings.legacy-syntaxes Deprecated Syntaxes
+@module can-stache-bindings.legacy-syntaxes Deprecated Syntaxes
 @parent can-stache-bindings.syntaxes 5
 
 Provides template event, one-way bindings, and two-way bindings.
@@ -22,7 +21,7 @@ The deprecated bindings are as follows:
 
 Prepending `$` to a binding like `($event)="key()"` changes the binding from the `ViewModel` to the element’s attributes or properties.
 
-> __Note:__ DOM attribute names are case-insensitive, use hypens (-) to in the attribute name to setup camelCase bindings.
+> __Note:__ DOM attribute names are case-insensitive, use hyphens (-) to in the attribute name to setup camelCase bindings.
 
 The following are the deprecated bindings that can be used with [can-stache]:
 

--- a/docs/legacy/event.md
+++ b/docs/legacy/event.md
@@ -66,7 +66,7 @@ handler in the order they were given.
 The following uses `($click)="items.splice(%index,1)"` to remove a
 item from `items` when that item is clicked on.
 
-@demo demos/can-stache-bindings/event-args.html
+@demo demos/can-stache-bindings-legacy/event-args.html
 
 ### Special Event Types
 

--- a/docs/legacy/event.md
+++ b/docs/legacy/event.md
@@ -3,6 +3,8 @@
 
 @description Respond to events on elements or component ViewModels.
 
+@deprecated {3.8} This syntax is deprecated in favor of [can-stache-bindings.event on:VIEW_MODEL_OR_DOM_EVENT='CALL_EXPRESSION']
+
 @signature `($DOM_EVENT)='CALL_EXPRESSION'`
 
 Listens to an event on the element and calls the [can-stache/expressions/call] when that event occurs.

--- a/docs/legacy/reference.md
+++ b/docs/legacy/reference.md
@@ -3,7 +3,7 @@
 
 @description Export a viewModel into a template's references scope.
 
-@deprecated {4.0} This syntax is deprecated in favor of [can-stache-bindings.toParent `this:to="scope.vars.refProp"`]
+@deprecated {3.10} This syntax is deprecated in favor of [can-stache-bindings.toParent this:to="scope.vars.refProp"]
 
 @signature `*ref-prop`
 

--- a/docs/legacy/reference.md
+++ b/docs/legacy/reference.md
@@ -1,5 +1,5 @@
 @function can-stache-bindings.reference *REFERENCE
-@parent can-stache-bindings.syntaxes 4
+@parent can-stache-bindings.legacy-syntaxes 4
 
 @description Export a viewModel into a template's references scope.
 

--- a/docs/legacy/reference.md
+++ b/docs/legacy/reference.md
@@ -23,4 +23,4 @@ hyphenated name of the reference scope property:
 ```
 
 
-@demo demos/can-stache-bindings/reference-one-way.html
+@demo demos/can-stache-bindings-legacy/reference-one-way.html

--- a/docs/legacy/to-child.md
+++ b/docs/legacy/to-child.md
@@ -43,4 +43,4 @@
 <player-scores {scores}="game.scoresForPlayer('Jeff')"/>
 ```
 
-@demo demos/can-stache-bindings/to-child.html
+@demo demos/can-stache-bindings-legacy/to-child.html

--- a/docs/legacy/to-child.md
+++ b/docs/legacy/to-child.md
@@ -3,6 +3,8 @@
 
 @description One-way bind a value in the parent scope to the [can-component.prototype.ViewModel ViewModel].
 
+@deprecated {3.8} This syntax is deprecated in favor of [can-stache-bindings.toChild childProp:from="key"]
+
 @signature `{child-prop}="key"`
 
   Imports [can-stache.key] in the [can-view-scope scope] to `childProp` in [can-component.prototype.view-model viewModel]. It also updates `childProp` with the value of `key` when `key` changes.

--- a/docs/legacy/to-parent.md
+++ b/docs/legacy/to-parent.md
@@ -50,7 +50,7 @@ In the following example, it connects the __selected__ driver in `<drivers-list>
     <drivers-list {^selected}="*editing"/>
     <edit-plate {(plate-name)}="*editing.licensePlate"/>
 
-@demo demos/can-stache-bindings/to-parent.html
+@demo demos/can-stache-bindings-legacy/to-parent.html
 
 ## Exporting DOM properties
 
@@ -78,6 +78,6 @@ And pass the method like:
 
 Check it out in this demo:
 
-@demo demos/can-stache-bindings/to-parent-function.html
+@demo demos/can-stache-bindings-legacy/to-parent-function.html
 
 Notice that `@` is used to prevent reading the function.  

--- a/docs/legacy/to-parent.md
+++ b/docs/legacy/to-parent.md
@@ -3,6 +3,8 @@
 
 @description One-way bind a value in the current [can-component.prototype.view-model viewModel] to the parent scope.
 
+@deprecated {3.8} This syntax is deprecated in favor of [can-stache-bindings.toParent childProp:to="key"]
+
 @signature `{^child-prop}="key"`
 
 Exports `childProp` in the [can-component.prototype.ViewModel ViewModel] to [can-stache.key] in the parent [can-view-scope scope]. It also updates

--- a/docs/legacy/two-way.md
+++ b/docs/legacy/two-way.md
@@ -50,11 +50,11 @@ The following two-way binds the `<edit-plate>` element’s `plateName` to the `e
 value in the scope.  This allows `plateName` to update if `editing.licensePlate` changes and
 `editing.licensePlate` to update if `plateName` changes.
 
-@demo demos/can-stache-bindings/two-way.html
+@demo demos/can-stache-bindings-legacy/two-way.html
 
 This demo can be expressed a bit easier with the references scope:
 
-@demo demos/can-stache-bindings/reference.html
+@demo demos/can-stache-bindings-legacy/reference.html
 
 ## Initialization
 

--- a/docs/legacy/two-way.md
+++ b/docs/legacy/two-way.md
@@ -3,6 +3,8 @@
 
 @description Two-way bind a value in the [can-component.prototype.view-model viewModel] or the element to the parent scope.
 
+@deprecated {3.8} This syntax is deprecated in favor of [can-stache-bindings.twoWay childProp:bind="key"]
+
 @signature `{(child-prop)}="key"`
 
   Two-way binds `childProp` in the  [can-component.prototype.ViewModel ViewModel] to

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,7 +3,7 @@
 
 @description Export a viewModel into a template's references scope.
 
-@deprecated {4.0} This syntax is deprecated in favor of [can-stache-bindings.toParent `this:to="refProp"`]
+@deprecated {4.0} This syntax is deprecated in favor of [can-stache-bindings.toParent `this:to="scope.vars.refProp"`]
 
 @signature `*ref-prop`
 
@@ -15,8 +15,8 @@
 
 ## Use
 
-Export a view model to the references scope by adding an attribute with the 
-hypenated name of the reference scope property:
+Export a view model to the references scope by adding an attribute with the
+hyphenated name of the reference scope property:
 
 ```
 <year-selector *year-selector />

--- a/docs/to-parent.md
+++ b/docs/to-parent.md
@@ -86,8 +86,8 @@ child component into the parent scope. Typically, the values are exported to the
 In the following example, it connects the __selected__ driver in `<drivers-list>` with an editable __plateName__ in
 `<edit-plate>`:
 
-    <drivers-list selected:to="*editing"/>
-    <edit-plate plateName:bind="*editing.licensePlate"/>
+    <drivers-list selected:to="scope.vars.editing"/>
+    <edit-plate plateName:bind="scope.vars.editing.licensePlate"/>
 
 @demo demos/can-stache-bindings/to-parent.html
 

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -1851,7 +1851,7 @@ test('one way - child to parent - importing viewModel {^prop}="test"', function(
 		'Imported: David',  '{name} component scope imported into variable');
 });
 
-test('one way - child to parent - importing viewModel {^hypenated-prop}="test"', function(){
+test('one way - child to parent - importing viewModel {^hyphenated-prop}="test"', function(){
 	MockComponent.extend({
 		tag: 'import-prop-scope',
 		template: stache('Hello {{userName}}'),
@@ -1879,7 +1879,7 @@ test('one way - child to parent - importing viewModel {^hypenated-prop}="test"',
 
 	var importPropParentViewModel = canViewModel(importPropParent);
 
-	equal(importPropParentViewModel.attr("test"), "Justin", "got hypenated prop");
+	equal(importPropParentViewModel.attr("test"), "Justin", "got hyphenated prop");
 
 	equal(importPropParentViewModel.attr("childComponent"), canViewModel(importPropScope), "got view model");
 
@@ -3182,7 +3182,7 @@ testHelpers.dev.devOnlyTest("warn when using reference shorthand", function() {
 
 	var template = stache("<reference-export *reference-export/>");
 
-	var teardown = testHelpers.dev.willWarn('*reference-export shorthand is deprecated. Use this:to="referenceExport" instead.');
+	var teardown = testHelpers.dev.willWarn('*reference-export shorthand is deprecated. Use this:to="scope.vars.referenceExport" instead.');
 	template({});
 	QUnit.equal(teardown(), 1, 'warning shown');
 });


### PR DESCRIPTION
A line like this: `*year-selector`

…previously suggested this: `Use this:to="yearSelector" instead.`

This PR fixes the warning to suggest this instead: `Use this:to="scope.vars.yearSelector" instead.`