### PR TITLE
Register parent to child (updateChild) callback dependencies

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -691,12 +691,12 @@ var bind = {
 			canReflect.onValue(childObservable, updateParent, "domUI");
 
 			//!steal-remove-start
-			updateParent[getChangesSymbol] = function() {
+			canReflectDeps.addMutatedBy(parentObservable, childObservable);
+			updateParent[getChangesSymbol] = function getChangesDependencyRecord() {
 				return {
 					valueDependencies: new Set([ parentObservable ])
 				};
 			};
-			canReflectDeps.addMutatedBy(parentObservable, childObservable);
 			//!steal-remove-end
 		}
 
@@ -705,7 +705,7 @@ var bind = {
 	// parent -> child binding
 	parentToChild: function(el, parentObservable, childObservable, bindingsSemaphore, attrName, bindingInfo) {
 		// setup listening on parent and forwarding to viewModel
-		var updateChild = function(newValue) {
+		var updateChild = function updateChild(newValue) {
 			// Save the viewModel property name so it is not updated multiple times.
 			// We listen for when the batch has ended, and all observation updates have ended.
 			bindingsSemaphore[attrName] = (bindingsSemaphore[attrName] || 0) + 1;
@@ -729,6 +729,11 @@ var bind = {
 			canReflect.onValue(parentObservable, updateChild, "domUI");
 			//!steal-remove-start
 			canReflectDeps.addMutatedBy(childObservable, parentObservable);
+			updateChild[getChangesSymbol] = function getChangesDependencyRecord() {
+				return {
+					valueDependencies: new Set([ childObservable])
+				};
+			};
 			//!steal-remove-end
 		}
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "can-view-callbacks": "^4.0.0-pre.4",
     "can-view-live": "^4.0.0-pre.16",
     "can-view-model": "^4.0.0-pre.4",
-    "can-view-scope": "^4.0.0-pre.34"
+    "can-view-scope": "^4.0.0-pre.37"
   },
   "devDependencies": {
     "can-define": "^2.0.0-pre.18",

--- a/test/colon/dependencies-test.js
+++ b/test/colon/dependencies-test.js
@@ -67,6 +67,41 @@ devOnlyTest("parent to child dependencies", function(assert) {
 	);
 });
 
+devOnlyTest("parent to child - map", function(assert) {
+	var template = stache('<input value:from="age">');
+
+	var map = new SimpleMap({ age: 10 });
+	var frag = template(map);
+
+	var ta = this.fixture;
+	ta.appendChild(frag);
+
+	var ageDeps = canReflectDeps.getDependencyDataOf(map, "age").whatChangesMe;
+	assert.ok(
+		ageDeps.mutate.valueDependencies.size,
+		"map.age should have mutation dependencies"
+	);
+
+	var scopeKeyData = Array.from(ageDeps.mutate.valueDependencies)[0];
+	var scopeKeyDataDeps = canReflectDeps.getDependencyDataOf(scopeKeyData)
+		.whatIChange;
+
+	assert.ok(
+		scopeKeyDataDeps.mutate.valueDependencies.size,
+		"the scopeKeyData should have [whatIChange] mutation dependencies"
+	);
+
+	var attributeObservable = Array.from(
+		scopeKeyDataDeps.mutate.valueDependencies
+	)[0];
+
+	assert.equal(
+		attributeObservable.constructor.name,
+		"AttributeObservable",
+		"scopeKeyData affects the AttributeObservable instance"
+	);
+});
+
 // input <-> attribute observation
 // parent: scope, child: viewModelOrAttribute
 devOnlyTest("child to parent dependencies", function(assert) {


### PR DESCRIPTION
This missing symbol was not breaking the [existing test](https://github.com/canjs/can-stache-bindings/blob/25895de67193d3de637cff168b06f0a069572a14/test/colon/dependencies-test.js#L24-L68) because the
test calls `getDependencyDataOf` [passing the input element](https://github.com/canjs/can-stache-bindings/blob/25895de67193d3de637cff168b06f0a069572a14/test/colon/dependencies-test.js#L34-L35) bound to
the property, and from the input node, the following arrow is visible:

AttributeObservable <- ScopeKeyData

(It is visible because the mutation dependency was registered)

The missing symbol would be an issue if `getDependencyDataOf` was passed
the ScopeKeyData instance instead (unlikely, since the ScopeKeyData instance
is only internally available); because it'd be impossible to get to
AttributeObservable through `getWhatIChange`.