### PR TITLE
Fix docs for exporting functions

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -47,9 +47,9 @@ Parameters are the same as [can-stache-bindings.event#on_VIEW_MODEL_OR_DOM_EVENT
 
 @signature `on:VIEW_MODEL_OR_DOM_EVENT:value:to='SCOPE_VALUE'`
 
-If the element has a [can-component::ViewModel ViewModel], listens to an event on the [can-component::ViewModel ViewModel] and binds the element's value to the SCOPE_VALUE when that event occurs.
+If the element has a [can-component::ViewModel ViewModel], listens to an event on the [can-component::ViewModel ViewModel] and binds the element’s value to the SCOPE_VALUE when that event occurs.
 
-If the element does **not** have a [can-component::ViewModel ViewModel], listens to an event on the element and binds binds the element's value to the SCOPE_VALUE when that event occurs.
+If the element does **not** have a [can-component::ViewModel ViewModel], listens to an event on the element and binds binds the element’s value to the SCOPE_VALUE when that event occurs.
 
 ```
 <my-component on:show:value:to="myScopeProp"/>
@@ -105,7 +105,7 @@ passed any number of arguments from the surrounding scope, or `name=value`
 attributes for named arguments. Direct arguments will be provided to the
 handler in the order they were given.
 
-The following uses `on:click="items.splice(%index,1)"` to remove a
+The following uses `on:click="items.splice(scope.index,1)"` to remove an
 item from `items` when that item is clicked on.
 
 @demo demos/can-stache-bindings/event-args.html
@@ -160,11 +160,11 @@ hides the player editor:
 
 ## Changing a property when an event occurs
 
-An event on either the element or viewModel can be set to bind the element's value to a property 
+An event on either the element or viewModel can be set to bind the element’s value to a property
 on the scope like:
 
 ```
 <input type="text" value="" on:blur:value:to="myScopeProp">
 ```
 
-This will set the value of myScopeProp to the input's value anytime the input loses focus.
+This will set the value of myScopeProp to the input’s value anytime the input loses focus.

--- a/docs/to-child.md
+++ b/docs/to-child.md
@@ -37,7 +37,7 @@
   Imports [can-stache.key] in the [can-view-scope scope] to `childProp` in [can-component.prototype.view-model viewModel]. It also updates `childProp` with the value of `key` when `key` changes.
 
   ```
-  <my-component vm:someProp:from="value"/>
+  <my-component vm:someProp:from="key"/>
   ```
 
   > __Note:__ If [can-stache.key] is an object, changes to the objects properties will still be visible to the component. Objects are passed by reference. See [can-stache-bindings#OneWayBindingWithObjects One Way Binding With Objects].
@@ -64,7 +64,8 @@ Parameters are the same as [can-stache-bindings.toChild#child_prop_from__key_ ch
 
 ## Use
 
-`childProp:from="key"` is used to pass values from the scope to a component.  You can use CallExpressions like:
+`childProp:from="key"` is used to pass values from the scope to a component.
+You can use [can-stache.expressions#Callexpressions call expressions] like:
 
 ```
 <player-scores scores:from="game.scoresForPlayer('Alison')"/>

--- a/docs/to-parent.md
+++ b/docs/to-parent.md
@@ -58,9 +58,9 @@ Parameters are the same as [can-stache-bindings.toParent#child_prop_to__key_ chi
 
 @signature `on:VIEW_MODEL_OR_DOM_EVENT:value:to='SCOPE_VALUE'`
 
-If the element has a [can-component::ViewModel ViewModel], listens to an event on the [can-component::ViewModel ViewModel] and binds the element's value to the SCOPE_VALUE when that event occurs.
+If the element has a [can-component::ViewModel ViewModel], listens to an event on the [can-component::ViewModel ViewModel] and binds the element’s value to the SCOPE_VALUE when that event occurs.
 
-If the element does **not** have a [can-component::ViewModel ViewModel], listens to an event on the element and binds binds the element's value to the SCOPE_VALUE when that event occurs.
+If the element does **not** have a [can-component::ViewModel ViewModel], listens to an event on the element and binds binds the element’s value to the SCOPE_VALUE when that event occurs.
 
 ```
 <my-component on:show:value:to="myScopeProp"/>
@@ -103,20 +103,22 @@ Updates `name` in the scope when the `<input>` element’s `value` changes.
 
 ## Exporting Functions
 
-You can export a function to the parent scope with a binding like:
+You can export a function to the [can-stache/keys/scope/scope.vars parent references scope]
+with a binding like:
 
 ```
-<my-tabs @addPanel:to="@*addPanel">
+<my-tabs @addPanel:to="scope.vars.addPanel">
 ```
 
 And pass the method like:
 
 ```
-<my-panel addPanel:from="@*addPanel" title="CanJS">CanJS Content</my-panel>
+<my-panel addPanel:from="scope.vars@addPanel" title:from="'CanJS'">CanJS Content</my-panel>
 ```
 
 Check it out in this demo:
 
 @demo demos/can-stache-bindings/to-parent-function.html
 
-Notice that `@` is used to prevent reading the function. You can read more about the [@ operator in the can-stache docs](https://canjs.com/doc/can-stache/keys/at.html).
+Notice that `@` is used to prevent reading the function. You can read more about
+the [can-stache/keys/at @ operator in the can-stache docs].


### PR DESCRIPTION
The old syntax was still being shown.

This also fixes some other minor things.