### PR TITLE
Only warn on prop="key" bindings if prop is defined on the viewModel

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -1220,24 +1220,6 @@ var makeDataBinding = function(node, el, bindingData) {
 		return;
 	}
 
-	//!steal-remove-start
-	if(
-		bindingInfo.child === "viewModel" &&
-		!isBindingsAttribute(bindingInfo.bindingAttributeName)
-	) {
-		var name = node.nodeName || node.name;
-		var value = node.nodeValue || node.value;
-		var filename = bindingData.scope.peek("scope.filename");
-		var lineNumber = bindingData.scope.peek('scope.lineNumber');
-
-		dev.warn(
-			(filename ? filename + ":" : "") +
-			(lineNumber ? lineNumber + ": " : "") +
-			name + "=\"" + value + "\" is deprecated. Use " + name + ":from=\"'" + value + "'\" instead."
-		);
-	}
-	//!steal-remove-end
-
 	// assign some bindingData props to the bindingInfo
 	bindingInfo.alreadyUpdatedChild = bindingData.alreadyUpdatedChild;
 	if( bindingData.initializeValues) {
@@ -1283,6 +1265,29 @@ var makeDataBinding = function(node, el, bindingData) {
 	// This completes the binding.  We can't call it right away because
 	// the `viewModel` might not have been created yet.
 	var completeBinding = function() {
+
+		//!steal-remove-start
+		if(
+			bindingInfo.child === "viewModel" &&
+			!isBindingsAttribute(bindingInfo.bindingAttributeName)
+		) {
+			// Check to see if the viewModel has the attribute name as a defined property
+			var viewModel = bindingData.getViewModel();
+			if (canReflect.hasOwnKey(viewModel, bindingInfo.bindingAttributeName) === false) {
+				var name = node.nodeName || node.name;
+				var value = node.nodeValue || node.value;
+				var filename = bindingData.scope.peek("scope.filename");
+				var lineNumber = bindingData.scope.peek('scope.lineNumber');
+
+				dev.warn(
+					(filename ? filename + ":" : "") +
+					(lineNumber ? lineNumber + ": " : "") +
+					name + "=\"" + value + "\" is deprecated. Use " + name + ":from=\"'" + value + "'\" instead."
+				);
+			}
+		}
+		//!steal-remove-end
+
 		if(bindingInfo.childToParent) {
 			// setup listening on parent and forwarding to viewModel
 			updateParent = bind.childToParent(el, parentObservable, childObservable, bindingData.semaphore, bindingInfo.bindingAttributeName,

--- a/test/bindings-test.js
+++ b/test/bindings-test.js
@@ -3350,7 +3350,7 @@ test("set string on the viewModel", function(){
 });
 
 test("warn about using attributes to set values on the viewModel", function(){
-	var teardown = testHelpers.dev.willWarn(/file.stache:1: .+=\".+\" is deprecated. Use .+:from=\"'.+'\" instead./);
+	var teardown = testHelpers.dev.willWarn("file.stache:1: foo=\"bar\" is deprecated. Use foo:from=\"'bar'\" instead.");
 	var ViewModel = DefaultMap.extend({
 		foo: {
 			type: "string"
@@ -3366,7 +3366,7 @@ test("warn about using attributes to set values on the viewModel", function(){
 
 	template();
 
-	equal(teardown(), 2);
+	equal(teardown(), 1);// 1 because it should warn on foo and not baz
 });
 
 // Add new tests above this line


### PR DESCRIPTION
This changes warnings like `title="" is deprecated. Use title:from="''" instead` to only happen when `title` is defined as a property on the viewModel.

Fixes https://github.com/donejs/donejs/issues/1062