### PR TITLE
Adds the 'raw' binding for passing in raw values

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -238,7 +238,6 @@ var behaviors = {
 			semaphore = {},
 			teardown;
 
-
 			// Setup binding
 			var dataBinding = makeDataBinding({
 				name: attrData.attributeName,
@@ -487,6 +486,7 @@ var behaviors = {
 viewCallbacks.attr(/[\w\.:]+:to$/, behaviors.data);
 viewCallbacks.attr(/[\w\.:]+:from$/, behaviors.data);
 viewCallbacks.attr(/[\w\.:]+:bind$/, behaviors.data);
+viewCallbacks.attr(/[\w\.:]+:raw$/, behaviors.data);
 // value:to:on:input="bar" data bindings
 viewCallbacks.attr(/[\w\.:]+:to:on:[\w\.:]+/, behaviors.data);
 viewCallbacks.attr(/[\w\.:]+:from:on:[\w\.:]+/, behaviors.data);
@@ -775,6 +775,11 @@ var bindingRules = {
 		childToParent: true,
 		parentToChild: true,
 		syncChildWithParent: true,
+	},
+	raw: {
+		childToParent: false,
+		parentToChild: true,
+		syncChildWithParent: false
 	}
 };
 var bindingNames = [];
@@ -861,7 +866,7 @@ var getBindingInfo = function(node, attributeViewModelBindings, templateType, ta
 			childName: result.tokens[specialIndex-1],
 			childEvent: childEventName,
 			bindingAttributeName: attributeName,
-			parentName: attributeValue,
+			parentName: result.special.raw ? ('"' + attributeValue + '"') : attributeValue,
 			initializeValues: initializeValues,
 		}, bindingRules[dataBindingName]);
 		if(attributeValue.trim().charAt(0) === "~") {

--- a/docs/raw.md
+++ b/docs/raw.md
@@ -1,0 +1,30 @@
+@function can-stache-bindings.raw toChild:raw
+@parent can-stache-bindings.syntaxes 4
+
+@description One-way bind a string value to the [can-component.prototype.ViewModel ViewModel] or element.
+
+@signature `childProp:raw="value"`
+
+  Sets the string value `"value"` to `childProp` in [can-component.prototype.view-model viewModel].
+
+  ```html
+  <my-component someProp:raw="35"/>
+  ```
+
+  @param {String} childProp The name of the property to set in the
+  component’s viewmodel.
+
+  @param {can-stache/expressions/literal} value A string literal from which `childProp` will be set.
+
+@body
+
+## Use
+
+`childProp:raw="value"` is used to set a value on a child ViewModel to a string value. Use this to avoid having to wrap raw values in quotes.
+
+The two uses below are equivalent.
+
+```html
+<player-scores scores:from="'37'"/>
+<player-scores scores:raw="37"/>
+```

--- a/test/data/tests.js
+++ b/test/data/tests.js
@@ -75,4 +75,10 @@ testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO
 		});
 		viewModel.attr('isShowing', false);
 	});
+
+	QUnit.test("raw bindings using :raw", function(assert){
+		var template = stache("<span foo:raw='bar'></span>");
+		var frag = template();
+		assert.equal(frag.firstChild.getAttribute("foo"), "bar", "bound raw");
+	});
 });


### PR DESCRIPTION
This adds a new type of binding, 'raw', for passing in raw values. It
can be used like:

```js
<my-counter count:raw="5" />
```

This prevents the need to wrap raw values in quotes. Fixes #382