### PR TITLE
Scope parent-to-child should set undefined correctly

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -759,7 +759,11 @@ var getObservableFrom = {
 			} else {
 				var observation = new Observation(function() {});
 
-				observation[canSymbol.for(setValueSymbol)] = function(newVal) {
+				observation[canSymbol.for(getValueSymbol)] = function getValue(newVal) {
+					return scope.get(cleanVMName(scopeProp));
+				};
+
+				observation[canSymbol.for(setValueSymbol)] = function setValue(newVal) {
 					scope.set(cleanVMName(scopeProp), newVal);
 				};
 

--- a/test/bindings-colon-test.js
+++ b/test/bindings-colon-test.js
@@ -138,6 +138,39 @@ test("basics", 5, function(){
 
 });
 
+QUnit.test("scope child-to-parent propagates undefined value", function() {
+	var viewModel = new SimpleMap({ toParent: "toParent" });
+	MockComponent.extend({
+		tag: "basic-colon",
+		viewModel: viewModel
+	});
+
+	var template = stache("<basic-colon toParent:to='valueB' />");
+	var parent = new SimpleMap({ valueB: "B" });
+	template(parent);
+
+	QUnit.deepEqual(
+		parent.get(),
+		{ valueB: "toParent" },
+		"initial scope values correct"
+	);
+
+	QUnit.deepEqual(
+		viewModel.get(),
+		{ toParent: "toParent" },
+		"initial VM values correct"
+	);
+
+	// Change vm
+	viewModel.set({ toParent: undefined });
+
+	QUnit.deepEqual(
+		parent.get(),
+		{ valueB: undefined },
+		"vm set undefined correctly"
+	);
+});
+
 test("getBindingInfo", function(){
 	var info = stacheBindings.getBindingInfo({name: "foo-ed:from", value: "bar"});
 	deepEqual(info, {


### PR DESCRIPTION
Closes #399 

Since the observable created by `scope: fn` had no value (always undefined)

https://github.com/canjs/can-stache-bindings/blob/3bb628ca11a165db9b525b9d43adaf56fdb22861/can-stache-bindings.js#L760

When `undefined` was set to the child vm (either manually or through `removeAttr`), `childToParent` will fail to update the parent vm, here:

https://github.com/canjs/can-stache-bindings/blob/3bb628ca11a165db9b525b9d43adaf56fdb22861/can-stache-bindings.js#L892

Implementing `getValueSymbol` on the "custom" `Observation` fixes the issue.

![kapture 2018-02-27 at 11 14 36](https://user-images.githubusercontent.com/724877/36746694-321de128-1bb0-11e8-864c-59e619bdfa02.gif)
