### PR TITLE
Make the docs alphabetical

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -1,5 +1,5 @@
 @function can-stache-bindings.event on:event
-@parent can-stache-bindings.syntaxes 0
+@parent can-stache-bindings.syntaxes
 
 @description Respond to events on elements or component ViewModels.
 

--- a/docs/raw.md
+++ b/docs/raw.md
@@ -1,5 +1,5 @@
 @function can-stache-bindings.raw toChild:raw
-@parent can-stache-bindings.syntaxes 4
+@parent can-stache-bindings.syntaxes
 
 @description One-way bind a string value to the [can-component.prototype.ViewModel ViewModel] or element.
 

--- a/docs/to-child.md
+++ b/docs/to-child.md
@@ -1,5 +1,5 @@
 @function can-stache-bindings.toChild toChild:from
-@parent can-stache-bindings.syntaxes 1
+@parent can-stache-bindings.syntaxes
 
 @description One-way bind a value in the parent scope to the [can-component.prototype.ViewModel ViewModel] or element.
 

--- a/docs/to-parent.md
+++ b/docs/to-parent.md
@@ -1,5 +1,5 @@
 @function can-stache-bindings.toParent toParent:to
-@parent can-stache-bindings.syntaxes 2
+@parent can-stache-bindings.syntaxes
 
 @description One-way bind a value from the [can-component.prototype.view-model viewModel] or element to the parent scope.
 

--- a/docs/two-way.md
+++ b/docs/two-way.md
@@ -1,5 +1,5 @@
 @function can-stache-bindings.twoWay twoWay:bind
-@parent can-stache-bindings.syntaxes 3
+@parent can-stache-bindings.syntaxes
 
 @description Two-way bind a value in the [can-component.prototype.view-model viewModel] or the element to the parent scope.
 


### PR DESCRIPTION
Previously they showed up out of alphabetical order, which made them more difficult to scan through.

Before:
<img width="169" alt="screen shot 2018-03-07 at 10 44 29 am" src="https://user-images.githubusercontent.com/10070176/37111558-d91f2e1a-21f4-11e8-86db-7d21ae50d507.png">

After:
<img width="170" alt="screen shot 2018-03-07 at 10 44 57 am" src="https://user-images.githubusercontent.com/10070176/37111571-dec7fd88-21f4-11e8-992e-c6684a621031.png">
