### PR TITLE
Use can-bind internally

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "can-assign": "^1.0.0",
     "can-attribute-encoder": "^1.0.0",
     "can-attribute-observable": "<2.0.0",
+    "can-bind": "<2.0.0",
     "can-dom-data-state": "^1.0.0",
     "can-dom-events": "^1.1.1",
     "can-dom-mutate": "^1.0.1",


### PR DESCRIPTION
This replaces can-stache-bindings’ system of creating data bindings with can-bind, which has the same functionality.

Closes https://github.com/canjs/can-stache-bindings/issues/451