### PR TITLE
Remove can-util as a dependency

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -17,9 +17,7 @@ var observeReader = require('can-stache-key');
 var ObservationRecorder = require('can-observation-recorder');
 var SimpleObservable = require('can-simple-observable');
 
-var assign = require('can-util/js/assign/assign');
-var makeArray  = require('can-util/js/make-array/make-array');
-var each  = require('can-util/js/each/each');
+var assign = require('can-assign');
 var dev = require('can-log/dev/dev');
 var domMutate = require('can-dom-mutate');
 var domData = require('can-dom-data-state');
@@ -125,7 +123,7 @@ var behaviors = {
 		// For each attribute, we start the binding process,
 		// and save what's returned to be used when the `viewModel` is created,
 		// the element is removed, or the attribute changes values.
-		each(makeArray(el.attributes), function(node) {
+		canReflect.each(el.attributes || [], function(node) {
 			var dataBinding = makeDataBinding(node, el, {
 				templateType: tagData.templateType,
 				scope: tagData.scope,
@@ -787,7 +785,7 @@ var special = {
 	vm: true,
 	on: true
 };
-each(bindingRules, function(value, key){
+canReflect.each(bindingRules, function(value, key){
 	bindingNames.push(key);
 	special[key] = true;
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "main": "can-stache-bindings"
   },
   "dependencies": {
+    "can-assign": "^1.0.0",
     "can-attribute-encoder": "^1.0.0",
     "can-attribute-observable": "^0.2.0",
     "can-dom-data-state": "^1.0.0",
@@ -46,7 +47,6 @@
     "can-stache": "^4.0.2",
     "can-stache-key": "^1.0.0",
     "can-symbol": "^1.0.0",
-    "can-util": "^3.9.0",
     "can-view-callbacks": "^4.0.0",
     "can-view-live": "^4.0.5",
     "can-view-model": "^4.0.0",

--- a/test/colon/element-test.js
+++ b/test/colon/element-test.js
@@ -17,7 +17,6 @@ var domMutate = require('can-dom-mutate');
 var domMutateNode = require('can-dom-mutate/node');
 var domEvents = require('can-dom-events');
 
-var canEach = require('can-util/js/each/each');
 var DefineMap = require("can-define/map/map");
 
 testHelpers.makeTests("can-stache-bindings - colon - element", function(name, doc, enableMO, testIfRealDocument){
@@ -464,7 +463,7 @@ testHelpers.makeTests("can-stache-bindings - colon - element", function(name, do
 				}
 			}
 		});
-		
+
 		var frag = template(viewModel);
 		domMutateNode.appendChild.call(this.fixture, frag);
 
@@ -905,7 +904,7 @@ testHelpers.makeTests("can-stache-bindings - colon - element", function(name, do
 		equal(inputs[0].value, 'green', "alternate value set");
 
 
-		canEach(ta.getElementsByTagName('option'), function(opt) {
+		canReflect.each(ta.getElementsByTagName('option'), function(opt) {
 			if (opt.value === 'red') {
 				opt.selected = 'selected';
 			}
@@ -915,7 +914,7 @@ testHelpers.makeTests("can-stache-bindings - colon - element", function(name, do
 		domEvents.dispatch(inputs[0], "change");
 		equal(map.get("color"), "red", "updated from input");
 
-		canEach(ta.getElementsByTagName('option'), function(opt) {
+		canReflect.each(ta.getElementsByTagName('option'), function(opt) {
 			if (opt.value === 'green') {
 				opt.selected = 'selected';
 			}


### PR DESCRIPTION
This replaces all the code that was using can-util with equivalent usages of can-reflect and can-assign.