### PR TITLE
Prevent auto-registration of bindings

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -11,7 +11,6 @@
 // - makeDataBinding - A helper method for setting up a data binding.
 // - initializeValues - A helper that initializes a data binding.
 var expression = require('can-stache/src/expression');
-var viewCallbacks = require('can-view-callbacks');
 var canViewModel = require('can-view-model');
 var observeReader = require('can-stache-key');
 var ObservationRecorder = require('can-observation-recorder');
@@ -33,6 +32,9 @@ var ViewNodeList = require("can-view-nodelist");
 
 var canEvent = require("can-attribute-observable/event");
 var noop = function() {};
+
+// Contains all of the stache bindings that will be exported.
+var bindings = new Map();
 
 var onMatchStr = "on:",
 	vmMatchStr = "vm:",
@@ -498,18 +500,18 @@ var behaviors = {
 // value:to="bar" data bindings
 // these are separate so that they only capture at the end
 // to avoid (toggle)="bar" which is encoded as :lp:toggle:rp:="bar"
-viewCallbacks.attr(/[\w\.:]+:to$/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:from$/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:bind$/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:raw$/, behaviors.data);
+bindings.set(/[\w\.:]+:to$/, behaviors.data);
+bindings.set(/[\w\.:]+:from$/, behaviors.data);
+bindings.set(/[\w\.:]+:bind$/, behaviors.data);
+bindings.set(/[\w\.:]+:raw$/, behaviors.data);
 // value:to:on:input="bar" data bindings
-viewCallbacks.attr(/[\w\.:]+:to:on:[\w\.:]+/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:from:on:[\w\.:]+/, behaviors.data);
-viewCallbacks.attr(/[\w\.:]+:bind:on:[\w\.:]+/, behaviors.data);
+bindings.set(/[\w\.:]+:to:on:[\w\.:]+/, behaviors.data);
+bindings.set(/[\w\.:]+:from:on:[\w\.:]+/, behaviors.data);
+bindings.set(/[\w\.:]+:bind:on:[\w\.:]+/, behaviors.data);
 
 
 // `(EVENT)` event bindings.
-viewCallbacks.attr(/on:[\w\.:]+/, behaviors.event);
+bindings.set(/on:[\w\.:]+/, behaviors.event);
 
 // ## getObservableFrom
 // An object of helper functions that make a getter/setter observable
@@ -1073,7 +1075,12 @@ cleanVMName = function(name, scope) {
 	return name.replace(/@/g, "");
 };
 
-module.exports = {
+var canStacheBindings = {
 	behaviors: behaviors,
-	getBindingInfo: getBindingInfo
+	getBindingInfo: getBindingInfo,
+	bindings: bindings
 };
+
+canStacheBindings[canSymbol.for("can.stacheBindings")] = bindings;
+
+module.exports = canStacheBindings;

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -21,6 +21,19 @@ bindings on element attributes, component [can-component::ViewModel ViewModels],
 
 __Note:__ DOM attribute names are case-insensitive, but [can-component::ViewModel ViewModel] or [can-view-scope scope] properties can be `camelCase` and [can-stache stache] will encode them so they work correctly in the DOM.
 
+## Installing can-stache-bindings
+
+To install can-stache-bindings so they can be used in your templates import the package and register it with [can-stache.addBindings] like so:
+
+```js
+import stacheBindings from 'can-stache-bindings';
+import stache from 'can-stache';
+
+stache.addBindings(stacheBindings);
+```
+
+## Binding types
+
 The following are the bindings that should be used with [can-stache]:
 
 #### [can-stache-bindings.event event]

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "can-reflect-dependencies": "^1.0.0",
     "can-simple-map": "^4.0.0",
     "can-simple-observable": "^2.0.0",
-    "can-stache": "^4.0.2",
+    "can-stache": "^4.7.0",
     "can-stache-key": "^1.0.0",
     "can-symbol": "^1.0.0",
     "can-view-callbacks": "^4.0.0",

--- a/test/colon/basics-test.js
+++ b/test/colon/basics-test.js
@@ -11,6 +11,8 @@ var MockComponent = require("../mock-component-simple-map");
 
 var canTestHelpers = require('can-test-helpers');
 
+stache.addBindings(stacheBindings);
+
 testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc, enableMO){
 
 	test("basics", 5, function(){

--- a/test/colon/dependencies-test.js
+++ b/test/colon/dependencies-test.js
@@ -6,7 +6,9 @@ var canViewModel = require("can-view-model");
 var canReflectDeps = require("can-reflect-dependencies");
 
 var stache = require("can-stache");
-require("can-stache-bindings");
+var stacheBindings = require("can-stache-bindings");
+
+stache.addBindings(stacheBindings);
 
 QUnit.module("bindings dependencies", {
 	beforeEach: function() {

--- a/test/colon/element-test.js
+++ b/test/colon/element-test.js
@@ -2,7 +2,7 @@ var QUnit = require('steal-qunit');
 var testHelpers = require('../helpers');
 
 var stache = require('can-stache');
-require('can-stache-bindings');
+var stacheBindings = require('can-stache-bindings');
 
 var SimpleMap = require("can-simple-map");
 var DefineList = require("can-define/list/list");
@@ -18,6 +18,8 @@ var domMutateNode = require('can-dom-mutate/node');
 var domEvents = require('can-dom-events');
 
 var DefineMap = require("can-define/map/map");
+
+stache.addBindings(stacheBindings);
 
 testHelpers.makeTests("can-stache-bindings - colon - element", function(name, doc, enableMO, testIfRealDocument){
 

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -1,8 +1,7 @@
 var QUnit = require('steal-qunit');
 var testHelpers = require('../helpers');
 
-require('can-stache-bindings');
-
+var stacheBindings = require('can-stache-bindings');
 var stache = require('can-stache');
 var MockComponent = require("../mock-component-simple-map");
 
@@ -17,6 +16,8 @@ var domData = require('can-dom-data-state');
 var domMutate = require('can-dom-mutate');
 var domMutateNode = require('can-dom-mutate/node');
 var domEvents = require('can-dom-events');
+
+stache.addBindings(stacheBindings);
 
 testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc, enableMO){
 

--- a/test/colon/hybrid-test.js
+++ b/test/colon/hybrid-test.js
@@ -1,12 +1,13 @@
 var QUnit = require('steal-qunit');
 var testHelpers = require('../helpers');
 
-require('can-stache-bindings');
-
+var stacheBindings = require('can-stache-bindings');
 var stache = require('can-stache');
 
 var SimpleMap = require("can-simple-map");
 var domEvents = require("can-dom-events");
+
+stache.addBindings(stacheBindings);
 
 testHelpers.makeTests("can-stache-bindings - colon - hybrids", function(name, doc, enableMO){
 

--- a/test/colon/view-model-test.js
+++ b/test/colon/view-model-test.js
@@ -1,8 +1,7 @@
 var QUnit = require('steal-qunit');
 var testHelpers = require('../helpers');
 
-require('can-stache-bindings');
-
+var stacheBindings = require('can-stache-bindings');
 var stache = require('can-stache');
 
 var SimpleMap = require("can-simple-map");
@@ -20,6 +19,8 @@ var canReflect = require('can-reflect');
 var queues = require("can-queues");
 
 var canTestHelpers = require('can-test-helpers');
+
+stache.addBindings(stacheBindings);
 
 testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, doc, enableMO){
 
@@ -597,15 +598,15 @@ testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, 
 			tag: "test-elem",
 			viewModel: SimpleMap
 		});
-	
+
 		var template = stache("<test-elem foo=\"bar\"/>");
-	
+
 		var frag = template(new SimpleMap({
 			bar: true
 		}));
-	
+
 		var vm = canViewModel(frag.firstChild);
-	
+
 		equal(vm.get('foo'), undefined);
 	});
 

--- a/test/data/tests.js
+++ b/test/data/tests.js
@@ -1,12 +1,13 @@
 var QUnit = require('steal-qunit');
 var testHelpers = require('../helpers');
 
-require('can-stache-bindings');
-
+var stacheBindings = require('can-stache-bindings');
 var stache = require('can-stache');
 var SimpleMap = require("can-simple-map");
 var domMutate = require('can-dom-mutate');
 var domMutateNode = require('can-dom-mutate/node');
+
+stache.addBindings(stacheBindings);
 
 testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO, testIfRealDocument){
 	QUnit.test('event bindings should be removed when the bound element is', function (assert) {


### PR DESCRIPTION
This makes can-stache-bindings no longer be side-effectual. Instead of
registering its attr callbacks itself, it defers to the end developer to
use the new `stache.addBindings()` API to do so.

```js
import stache from "can-stache";
import stacheBindings from "can-stache-bindings";

stache.addBindings(stacheBindings);
```

*Note* that in reality anyone using can-component will not need to do
this, as can-component will. __However__ it is still a breaking change.

Closes #464