### PR TITLE
Created ability to use functions in simple setter form

### DIFF
--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -562,6 +562,33 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 
 		QUnit.equal(map.get("prop"), 8, "can set to result of calling a function");
 
+		// As functions
 
+		MockComponent.extend({
+			tag: 'my-button',
+			template: stache("<button on:click=\"this.clicked()\">Click me</button>"),
+			viewModel: {
+				clicked: null
+			}
+		});
+
+		map = new SimpleMap({
+			clickCount: 0
+		});
+
+		template = stache("<my-button clicked:from=\"this.clickCount = 1\"></my-button>");
+
+		frag = template(map);
+		var button = frag.firstChild;
+		var myButton = button.firstChild;
+
+		QUnit.equal(typeof button.viewModel.get('clicked'), 'function', 'has function');
+
+		// Dispatch click on the my-button button
+		domEvents.dispatch(myButton, {
+			type: "click"
+		});
+
+		QUnit.equal(map.get("clickCount"), 1, "function got called");
 	});
 });

--- a/test/mock-component-simple-map.js
+++ b/test/mock-component-simple-map.js
@@ -25,6 +25,7 @@ module.exports = MockComponent = {
 
 			}, {});
 			el[canSymbol.for('can.viewModel')] = viewModel;
+			el.viewModel = viewModel;
 			domData.set.call(el, "preventDataBindings", true);
 
 			if(proto.template) {

--- a/test/mock-component.js
+++ b/test/mock-component.js
@@ -24,6 +24,7 @@ module.exports = MockComponent = {
 
 			}, {});
 			el[canSymbol.for('can.viewModel')] = viewModel;
+			el.viewModel = viewModel;
 			domData.set.call(el, "preventDataBindings", true);
 
 			if(proto.template) {


### PR DESCRIPTION
Allow simple setter form for functions:

```javascript
<my-component close:from="this.closed = true" />
```

ref: https://github.com/canjs/can-stache-bindings/issues/497