### PR TITLE
Use expr.parse to fix issue with bracket expression with :to

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -600,7 +600,9 @@ var getObservableFrom = {
 					},
 
 					"can.setValue": function setValue(newVal) {
-						scope.set(cleanVMName(scopeProp, scope), newVal);
+						var expr = expression.parse(cleanVMName(scopeProp, scope),{baseMethodType: "Call"});
+						var value = expr.value(scope);
+						canReflect.setValue(value, newVal);
 					},
 
 					// Register what the custom observation changes

--- a/test/colon/element-test.js
+++ b/test/colon/element-test.js
@@ -1287,4 +1287,32 @@ testHelpers.makeTests("can-stache-bindings - colon - element", function(name, do
 			console.groupCollapsed = groupCollapsed;
 		}
 	});
+
+	testIfRealDocument("Bracket Expression with :to bindings", function () {
+		var demoContext = new DefineMap({
+			person: {
+				name: 'Matt'
+			}
+		});
+
+		var SourceComponentVM = DefineMap.extend("SourceComponentVM", {
+			name: {
+				value: 'Kevin'
+			}
+		});
+
+		MockComponent.extend({
+			tag: "source-component",
+			viewModel: SourceComponentVM,
+			template: stache('<span>{{name}}</span>')
+		});
+
+		var demoRenderer = stache(
+			'<source-component name:to="person[\'name\']" />'
+		);
+
+		demoRenderer(demoContext);
+
+		QUnit.equal(demoContext.person.name, 'Kevin', "source-component has correct name set");
+	});
 });

--- a/test/colon/element-test.js
+++ b/test/colon/element-test.js
@@ -1297,7 +1297,7 @@ testHelpers.makeTests("can-stache-bindings - colon - element", function(name, do
 
 		var SourceComponentVM = DefineMap.extend("SourceComponentVM", {
 			name: {
-				value: 'Kevin'
+				default: 'Kevin'
 			}
 		});
 


### PR DESCRIPTION
This fixes https://github.com/canjs/can-stache-bindings/issues/496 allowing bracket notation with `:to`