### PR TITLE
Refactor to enable new Component() reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "can-assign": "^1.0.0",
     "can-attribute-encoder": "^1.1.1",
     "can-attribute-observable": "^1.2.1",
-    "can-bind": "^1.3.0",
+    "can-bind": "^1.4.0",
     "can-dom-data-state": "^1.0.0",
     "can-dom-events": "^1.3.3",
     "can-dom-mutate": "^1.3.0",

--- a/test/colon/basics-test.js
+++ b/test/colon/basics-test.js
@@ -11,6 +11,24 @@ var MockComponent = require("../mock-component-simple-map");
 var encoder = require("can-attribute-encoder");
 var canTestHelpers = require('can-test-helpers');
 
+
+function siblingsDataToInfo(siblingData) {
+
+	return {
+		parent: siblingData.parent.source,
+		child: siblingData.child.source,
+		childEvent: siblingData.child.event,
+		parentToChild: siblingData.parent.exports,
+		childToParent:  siblingData.child.exports,
+		childName:  siblingData.child.name,
+		parentName:  siblingData.parent.name,
+		bindingAttributeName: siblingData.bindingAttributeName,
+		initializeValues: siblingData.initializeValues,
+		syncChildWithParent: siblingData.parent.syncSibling
+	};
+
+}
+
 testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc, enableMO){
 
 	test("basics", 5, function(){
@@ -86,9 +104,10 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 
 	});
 
-	test("getBindingInfo", function(){
-		var info = stacheBindings.getBindingInfo({name: "foo-ed:from", value: "bar"});
-		deepEqual(info, {
+	test("getSiblingBindingData", function(){
+		var info = stacheBindings.getSiblingBindingData({name: "foo-ed:from", value: "bar"});
+
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModelOrAttribute",
 			childEvent: undefined,
@@ -101,8 +120,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":from");
 
-		info = stacheBindings.getBindingInfo({name: "foo-ed:bind", value: "bar"});
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "foo-ed:bind", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModelOrAttribute",
 			childEvent: undefined,
@@ -115,8 +134,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: true
 		}, ":bind");
 
-		info = stacheBindings.getBindingInfo({name: "foo-ed:to", value: "bar"});
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "foo-ed:to", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModelOrAttribute",
 			childEvent: undefined,
@@ -129,8 +148,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":to");
 
-		info = stacheBindings.getBindingInfo({name: "foo-ed:from", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "foo-ed:from", value: "bar"}, {favorViewModel: true});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -143,8 +162,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":from, favorViewModel=true");
 
-		info = stacheBindings.getBindingInfo({name: "foo-ed:bind", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "foo-ed:bind", value: "bar"}, {favorViewModel: true});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -157,8 +176,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: true
 		}, ":bind, favorViewModel=true");
 
-		info = stacheBindings.getBindingInfo({name: "foo-ed:to", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "foo-ed:to", value: "bar"}, {favorViewModel: true});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -172,9 +191,9 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 		}, ":to, favorViewModel=true");
 	});
 
-	test("getBindingInfo for vm:", function() {
-		var info = stacheBindings.getBindingInfo({name: "vm:foo-ed:from", value: "bar"});
-		deepEqual(info, {
+	test("getSiblingBindingData for vm:", function() {
+		var info = stacheBindings.getSiblingBindingData({name: "vm:foo-ed:from", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -187,8 +206,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":from");
 
-		info = stacheBindings.getBindingInfo({name: "vm:foo-ed:bind", value: "bar"});
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "vm:foo-ed:bind", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -201,8 +220,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: true
 		}, ":bind");
 
-		info = stacheBindings.getBindingInfo({name: "vm:foo-ed:to", value: "bar"});
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "vm:foo-ed:to", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -215,8 +234,9 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":to");
 
-		info = stacheBindings.getBindingInfo({name: "vm:foo-ed:from", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "vm:foo-ed:from", value: "bar"}, {favorViewModel: true});
+
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -229,8 +249,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":from, favorViewModel=true");
 
-		info = stacheBindings.getBindingInfo({name: "vm:foo-ed:bind", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "vm:foo-ed:bind", value: "bar"}, {favorViewModel: true});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -243,8 +263,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: true
 		}, ":bind, favorViewModel=true");
 
-		info = stacheBindings.getBindingInfo({name: "vm:foo-ed:to", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "vm:foo-ed:to", value: "bar"}, {favorViewModel: true});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModel",
 			childEvent: undefined,
@@ -258,9 +278,9 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 		}, ":to, favorViewModel=true");
 	});
 
-	test("getBindingInfo for el:", function() {
-		var info = stacheBindings.getBindingInfo({name: "el:foo-ed:from", value: "bar"});
-		deepEqual(info, {
+	test("getSiblingBindingData for el:", function() {
+		var info = stacheBindings.getSiblingBindingData({name: "el:foo-ed:from", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "attribute",
 			childEvent: undefined,
@@ -273,8 +293,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":from");
 
-		info = stacheBindings.getBindingInfo({name: "el:foo-ed:bind", value: "bar"});
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "el:foo-ed:bind", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "attribute",
 			childEvent: undefined,
@@ -287,8 +307,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: true
 		}, ":bind");
 
-		info = stacheBindings.getBindingInfo({name: "el:foo-ed:to", value: "bar"});
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "el:foo-ed:to", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "attribute",
 			childEvent: undefined,
@@ -301,8 +321,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":to");
 
-		info = stacheBindings.getBindingInfo({name: "el:foo-ed:from", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "el:foo-ed:from", value: "bar"}, null, null, null, true);
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "attribute",
 			childEvent: undefined,
@@ -315,8 +335,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: false
 		}, ":from, favorViewModel=true");
 
-		info = stacheBindings.getBindingInfo({name: "el:foo-ed:bind", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "el:foo-ed:bind", value: "bar"}, null, null, null, true);
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "attribute",
 			childEvent: undefined,
@@ -329,8 +349,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 			syncChildWithParent: true
 		}, ":bind, favorViewModel=true");
 
-		info = stacheBindings.getBindingInfo({name: "el:foo-ed:to", value: "bar"}, null, null, null, true);
-		deepEqual(info, {
+		info = stacheBindings.getSiblingBindingData({name: "el:foo-ed:to", value: "bar"}, null, null, null, true);
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "attribute",
 			childEvent: undefined,
@@ -344,10 +364,10 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 		}, ":to, favorViewModel=true");
 	});
 
-	QUnit.test("getBindingInfo works for value:to:on:click (#269)", function(){
+	QUnit.test("getSiblingBindingData works for value:to:on:click (#269)", function(){
 
-		var info = stacheBindings.getBindingInfo({name: "value:to:on:click", value: "bar"});
-		deepEqual(info, {
+		var info = stacheBindings.getSiblingBindingData({name: "value:to:on:click", value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModelOrAttribute",
 			childEvent: "click",
@@ -364,8 +384,8 @@ testHelpers.makeTests("can-stache-bindings - colon - basics", function(name, doc
 
 	QUnit.test("decode values with To (#504)", function(){
 		var name = encoder.encode("goToHome:to");
-		var info = stacheBindings.getBindingInfo({name: name, value: "bar"});
-		deepEqual(info, {
+		var info = stacheBindings.getSiblingBindingData({name: name, value: "bar"});
+		deepEqual(siblingsDataToInfo(info), {
 			parent: "scope",
 			child: "viewModelOrAttribute",
 			childEvent: undefined,


### PR DESCRIPTION
This refactor's goal is to make it possible to use some code in can-stache-bindings.  Specifically:

- `stacheBindings.getObservableFrom.viewModel(bindingData, bindingContext, bindingSettings, siblingObservable)` - so observables can be created around a ViewModel that has not been created yet.
- `stacheBindings.behaviors.initializeViewModel(bindings, initialViewModelData, makeViewModel [, bindingContext])` - to initialize a bunch of bindings, the view model and then complete the bindings

The primary restructuring involves creating a few different "options" types:

## siblingsBindingData

This is an object that represents a parsing of a binding attribute like `foo:from="bar"`.  It looks like:

```
{
  parent: {source: "scope", name: "bar", exports: true, syncSibling: false},
  child: {source: "viewModelOrAttribute", name: "foo", exports: false, syncSibling: false},
  bindingAttributeName: 'foo:from="bar"',
  initializeValues: true 
}
```

Methods like `stacheBindings.getObservableFrom.viewModel` get one of the child binding data objects:

```js
stacheBindings.getObservableFrom.viewModel( 
  {source: "viewModelOrAttribute", name: "foo", exports: false, syncSibling: false},
  {element, scope},
  {getViewModel()}
)
```

## bindingContext

These objects contain the information about where the stache binding happened:

```
{ element, scope, parentNodeList }
```

We might want to move `getViewModel` into this object.

## bindingSettings

This is for "global" binding overwrites

```
{ getViewModel, favorViewModel, alreadyUpdatedChild, attributeViewModelBindings }
```
