### PR TITLE
Warn when non-explicitly binding known DOM event names to a view model

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -530,7 +530,7 @@ var behaviors = {
 				if(
 					!eventBindingData.bindingCode &&
 					el[canSymbol.for("can.viewModel")] &&
-					("on" + event) in HTMLElement.prototype
+					("on" + event) in el
 				) {
 					dev.warn(
 						"The " + event + " event is bound the view model for <" + el.tagName.toLowerCase() +

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -527,12 +527,14 @@ var behaviors = {
 
 			//!steal-remove-start
 			if(process.env.NODE_ENV !== "production") {
-				if(!eventBindingData.bindingCode
-					&& el[canSymbol.for("can.viewModel")]
-					&& ("on" + event) in HTMLElement.prototype) {
+				if(
+					!eventBindingData.bindingCode &&
+					el[canSymbol.for("can.viewModel")] &&
+					("on" + event) in HTMLElement.prototype
+				) {
 					dev.warn(
-						"The " + event + " event is bound the view model for <" + el.tagName.toLowerCase()
-						+ ">. Use " + attributeName.replace(onMatchStr, "on:el:") +  " to bind to the element instead."
+						"The " + event + " event is bound the view model for <" + el.tagName.toLowerCase() +
+							">. Use " + attributeName.replace(onMatchStr, "on:el:") +  " to bind to the element instead."
 					);
 				}
 			}

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -102,12 +102,15 @@ var getEventBindingData = function (attributeName, el, scope) {
 	var bindingContext;
 	var eventName;
 	var bindingContextObservable;
+	var shortBindingCode = "";
 
 	// if explicit context is specified, trim the string down
 	// else, determine value of which scope being used elUsed, vmUsed, scopeUsed
 	if (vmUsed) {
+		shortBindingCode = "vm";
 		bindingCode = bindingCode.substr(vmMatchStr.length);
 	} else if (elUsed) {
+		shortBindingCode = "el";
 		bindingCode = bindingCode.substr(elMatchStr.length);
 	} else if (!vmUsed && !elUsed) {
 		if (byUsed) {
@@ -154,7 +157,9 @@ var getEventBindingData = function (attributeName, el, scope) {
 		// this observable emits the bindingContext
 		bindingContextObservable: bindingContextObservable,
 		// the eventName string
-		eventName: eventName
+		eventName: eventName,
+		// which binding code was explicitly set by the user
+		bindingCode: shortBindingCode,
 	};
 };
 
@@ -519,6 +524,19 @@ var behaviors = {
 			event = eventBindingData.eventName;
 			bindingContext = eventBindingData.bindingContext;
 			bindingContextObservable = eventBindingData.bindingContextObservable;
+
+			//!steal-remove-start
+			if(process.env.NODE_ENV !== "production") {
+				if(!eventBindingData.bindingCode
+					&& el[canSymbol.for("can.viewModel")]
+					&& ("on" + event) in HTMLElement.prototype) {
+					dev.warn(
+						"The " + event + " event is bound the view model for <" + el.tagName.toLowerCase()
+						+ ">. Use " + attributeName.replace(onMatchStr, "on:el:") +  " to bind to the element instead."
+					);
+				}
+			}
+			//!steal-remove-end
 		} else {
 			throw new Error("can-stache-bindings - unsupported event bindings " + attributeName);
 		}

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -1,10 +1,12 @@
 var QUnit = require('steal-qunit');
 var testHelpers = require('../helpers');
+var canTestHelpers = require('can-test-helpers');
 
 require('can-stache-bindings');
 
 var stache = require('can-stache');
 var MockComponent = require("../mock-component-simple-map");
+var viewCallbacks = require('can-view-callbacks');
 
 var SimpleMap = require("can-simple-map");
 
@@ -13,6 +15,7 @@ var DefineList = require("can-define/list/list");
 var SimpleObservable = require("can-simple-observable");
 var canViewModel = require('can-view-model');
 var canReflect = require("can-reflect");
+var canSymbol = require("can-symbol");
 
 var domData = require('can-dom-data-state');
 var domMutate = require('can-dom-mutate');
@@ -707,4 +710,23 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 		map.set("user", user2);
 		map.get("user").set("name", "Todd");
 	});
+});
+
+
+canTestHelpers.dev.devOnlyTest("warning when binding known DOM event name to view model", function() {
+	var teardown = canTestHelpers.dev.willWarn("The focus event is bound the view model for <warning-el>. Use on:el:focus to bind to the element instead.");
+	viewCallbacks.tag("warning-el", function(el) {
+		el[canSymbol.for("can.viewModel")] = new SimpleMap({});
+	});
+
+	var template = stache(
+		"<warning-el on:vm:click='scope.element.preventDefault()' " +
+			"on:el:change='scope.element.preventDefault()' " +
+			"on:foo='scope.element.preventDefault()' " +
+			"on:focus='scope.element.preventDefault()'/>"
+	);
+
+	var map = new SimpleMap({});
+	template(map);
+	QUnit.equal(teardown(), 1, 'warning shown');
 });

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -710,22 +710,25 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 		map.set("user", user2);
 		map.get("user").set("name", "Todd");
 	});
-});
 
-canTestHelpers.dev.devOnlyTest("warning when binding known DOM event name to view model", function() {
-	var teardown = canTestHelpers.dev.willWarn("The focus event is bound the view model for <warning-el>. Use on:el:focus to bind to the element instead.");
-	viewCallbacks.tag("warning-el", function(el) {
-		el[canSymbol.for("can.viewModel")] = new SimpleMap({});
+	canTestHelpers.dev.devOnlyTest("warning when binding known DOM event name to view model (dev-only wrapper)", function() {
+		expect(0);
+		testIfRealDocument("warning when binding known DOM event name to view model (real test)", function() {
+			var teardown = canTestHelpers.dev.willWarn("The focus event is bound the view model for <warning-el>. Use on:el:focus to bind to the element instead.");
+			viewCallbacks.tag("warning-el", function(el) {
+				el[canSymbol.for("can.viewModel")] = new SimpleMap({});
+			});
+
+			var template = stache(
+				"<warning-el on:vm:click='scope.element.preventDefault()' " +
+					"on:el:change='scope.element.preventDefault()' " +
+					"on:foo='scope.element.preventDefault()' " +
+					"on:focus='scope.element.preventDefault()'/>"
+			);
+
+			var map = new SimpleMap({});
+			template(map);
+			QUnit.equal(teardown(), 1, 'warning shown');
+		});
 	});
-
-	var template = stache(
-		"<warning-el on:vm:click='scope.element.preventDefault()' " +
-			"on:el:change='scope.element.preventDefault()' " +
-			"on:foo='scope.element.preventDefault()' " +
-			"on:focus='scope.element.preventDefault()'/>"
-	);
-
-	var map = new SimpleMap({});
-	template(map);
-	QUnit.equal(teardown(), 1, 'warning shown');
 });


### PR DESCRIPTION
To help address the user difficulty in #515, this PR adds a warning in development mode when using `on:event` to bind an event to a view model if the event name is one of the events common to the DOM (i.e. if "on" + the event name exists on HTMLElement.prototype).

The warning is not generated if a view model is not present (in which case the event is bound to the element), or if "on:vm:event" or "on:el:event" is used explicitly.