### PR TITLE
Handle two way binding with nested properties

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -15,7 +15,7 @@ var Bind = require('can-bind');
 var expression = require('can-stache/src/expression');
 var viewCallbacks = require('can-view-callbacks');
 var canViewModel = require('can-view-model');
-var observeReader = require('can-stache-key');
+var canStacheKey = require('can-stache-key');
 var ObservationRecorder = require('can-observation-recorder');
 var SimpleObservable = require('can-simple-observable');
 var Scope = require('can-view-scope');
@@ -763,11 +763,11 @@ var getObservableFrom = {
 
 		var setName = cleanVMName(vmName, scope);
 		var isBoundToContext = vmName === "." || vmName === "this";
-		var keysToRead = isBoundToContext ? [] : observeReader.reads(vmName);
+		var keysToRead = isBoundToContext ? [] : canStacheKey.reads(vmName);
 
 		function getViewModelProperty() {
 			var viewModel = bindingContext.viewModel;
-			return observeReader.read(viewModel, keysToRead, {}).value;
+			return canStacheKey.read(viewModel, keysToRead, {}).value;
 		}
 		//!steal-remove-start
 		if (process.env.NODE_ENV !== 'production') {
@@ -801,7 +801,7 @@ var getObservableFrom = {
 					if (isBoundToContext) {
 						canReflect.setValue(viewModel, newVal);
 					} else {
-						canReflect.setKeyValue(viewModel, setName, newVal);
+						canStacheKey.write(viewModel, keysToRead, newVal);
 					}
 				}
 			}

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -15,7 +15,7 @@ var Bind = require('can-bind');
 var expression = require('can-stache/src/expression');
 var viewCallbacks = require('can-view-callbacks');
 var canViewModel = require('can-view-model');
-var canStacheKey = require('can-stache-key');
+var stacheKey = require('can-stache-key');
 var ObservationRecorder = require('can-observation-recorder');
 var SimpleObservable = require('can-simple-observable');
 var Scope = require('can-view-scope');
@@ -763,11 +763,11 @@ var getObservableFrom = {
 
 		var setName = cleanVMName(vmName, scope);
 		var isBoundToContext = vmName === "." || vmName === "this";
-		var keysToRead = isBoundToContext ? [] : canStacheKey.reads(vmName);
+		var keysToRead = isBoundToContext ? [] : stacheKey.reads(vmName);
 
 		function getViewModelProperty() {
 			var viewModel = bindingContext.viewModel;
-			return canStacheKey.read(viewModel, keysToRead, {}).value;
+			return stacheKey.read(viewModel, keysToRead, {}).value;
 		}
 		//!steal-remove-start
 		if (process.env.NODE_ENV !== 'production') {
@@ -801,7 +801,7 @@ var getObservableFrom = {
 					if (isBoundToContext) {
 						canReflect.setValue(viewModel, newVal);
 					} else {
-						canStacheKey.write(viewModel, keysToRead, newVal);
+						stacheKey.write(viewModel, keysToRead, newVal);
 					}
 				}
 			}

--- a/test/colon/view-model-test.js
+++ b/test/colon/view-model-test.js
@@ -825,7 +825,7 @@ testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, 
 	QUnit.test("nested props with two way binding", function() {
 		var nestedValue = new SimpleMap({
 			first: 'Matt'
-		})
+		});
 		var childVM = new SimpleMap({
 			name: nestedValue
 		});

--- a/test/colon/view-model-test.js
+++ b/test/colon/view-model-test.js
@@ -821,4 +821,43 @@ testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, 
 		});
 		vm.dispatch({type: "event"},[1,2]);
 	});
+	
+	QUnit.test("nested props with two way binding", function() {
+		var nestedValue = new SimpleMap({
+			first: 'Matt'
+		})
+		var childVM = new SimpleMap({
+			name: nestedValue
+		});
+		MockComponent.extend({
+			tag: "my-child",
+			viewModel: childVM,
+			template: stache('<input value:bind="name.first" />')
+		});
+		var parentVM = new SimpleMap({
+			name: 'Justin'
+		});
+		MockComponent.extend({
+			tag: "my-parent",
+			viewModel: parentVM,
+			template: stache('<my-child name.first:bind="name" /><input value:bind="name" />')
+		});
+
+		var template = stache("<my-parent />")();
+
+		var parentInput = template.childNodes.item(0).childNodes.item(1);
+		var childInput = template.childNodes.item(0).childNodes.item(0).childNodes.item(0);
+
+		parentInput.value = 'updated';
+		domEvents.dispatch(parentInput, 'change');
+
+		QUnit.equal(parentVM.get('name'), 'updated', 'parent vm has correct value');
+		QUnit.equal(nestedValue.get('first'), 'updated', 'child vm has correct value');
+
+		childInput.value = 'child-updated';
+		domEvents.dispatch(childInput, 'change');
+
+		QUnit.equal(parentVM.get('name'), 'child-updated', 'parent vm has correct value');
+		QUnit.equal(nestedValue.get('first'), 'child-updated', 'child vm has correct value');
+	});
 });


### PR DESCRIPTION
Handle nested props with two way binding:

```html
<script id="app-template" type="text/stache">
  <home-page textData.textValue:bind="textString" />
  <input value:bind="textString"/>
</script>
  
<script id="home-template" type="text/stache">
  <h1>Home Page</h1>
  <input value:bind="textData.textValue" />
</script>
```

Resolves - https://github.com/canjs/can-stache/issues/408