### PR TITLE
Warn when the child side updates a sticky two-way binding on viewmodel init

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -349,31 +349,6 @@ var behaviors = {
 		var completedData = behaviors.initializeViewModel(dataBindings, initialViewModelData, function(){
 			// we need to make sure we have the viewModel available
 			bindingContext.viewModel = makeViewModel.apply(this, arguments);
-
-			// Here we want to do a dev-mode check to see whether the child does type conversions on
-			//  any two-way bindings.  This will be ignored and the child and parent will be desynched.
-			dataBindings.forEach(function(dataBinding) {
-				var binding = dataBinding.binding;
-				var childContext = binding.child.observation && binding.child.observation.func || binding.child;
-				var parentValue = canReflect.getValue(binding.parent);
-				var childValue = canReflect.getValue(binding.child);
-				if (
-					binding._parentToChild &&
-					binding._childToParent &&
-					parentValue != null &&
-					childValue !== parentValue
-				) {
-					dev.warn(
-						"can-stache-bindings: The child of the sticky two-way binding " +
-						canReflect.getName(childContext) +
-						" is changing or converting its value when set.  " +
-						"Conversions should only be done on the binding parent to preserve synchronization.  " +
-						"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings"
-					);
-				}
-			});
-
-
 		}, bindingContext),
 			onTeardowns = completedData.onTeardowns,
 			bindingsState = completedData.bindingsState,
@@ -1133,11 +1108,12 @@ var makeDataBinding = function(node, bindingContext, bindingSettings) {
 				return ""+child+"."+childName;
 			}
 		};
-		bindingOptions.updateChildName = tagStart+" "+nodeHTML+"> updates "+
+		bindingOptions.debugName = tagStart+" "+nodeHTML+">";
+		bindingOptions.updateChildName = bindingOptions.debugName+" updates "+
 			makeUpdateName(siblingBindingData.child.source, siblingBindingData.child.name)+
 			" from "+makeUpdateName(siblingBindingData.parent.source, siblingBindingData.parent.name);
 
-		bindingOptions.updateParentName = tagStart+" "+nodeHTML+"> updates "+
+		bindingOptions.updateParentName = bindingOptions.debugName+" updates "+
 			makeUpdateName(siblingBindingData.parent.source, siblingBindingData.parent.name)+
 			" from "+makeUpdateName(siblingBindingData.child.source, siblingBindingData.child.name);
 	}

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -349,6 +349,31 @@ var behaviors = {
 		var completedData = behaviors.initializeViewModel(dataBindings, initialViewModelData, function(){
 			// we need to make sure we have the viewModel available
 			bindingContext.viewModel = makeViewModel.apply(this, arguments);
+
+			// Here we want to do a dev-mode check to see whether the child does type conversions on
+			//  any two-way bindings.  This will be ignored and the child and parent will be desynched.
+			dataBindings.forEach(function(dataBinding) {
+				var binding = dataBinding.binding;
+				var childContext = binding.child.observation && binding.child.observation.func || binding.child;
+				var parentValue = canReflect.getValue(binding.parent);
+				var childValue = canReflect.getValue(binding.child);
+				if (
+					binding._parentToChild &&
+					binding._childToParent &&
+					parentValue != null &&
+					childValue !== parentValue
+				) {
+					dev.warn(
+						"can-stache-bindings: The child of the sticky two-way binding " +
+						canReflect.getName(childContext) +
+						" is changing or converting its value when set.  " +
+						"Conversions should only be done on the binding parent to preserve synchronization.  " +
+						"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings"
+					);
+				}
+			});
+
+
 		}, bindingContext),
 			onTeardowns = completedData.onTeardowns,
 			bindingsState = completedData.bindingsState,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "can-assign": "^1.0.0",
     "can-attribute-encoder": "^1.1.1",
     "can-attribute-observable": "^1.2.5",
-    "can-bind": "^1.4.0",
+    "can-bind": "^1.4.2",
     "can-dom-data": "^1.0.1",
     "can-dom-events": "^1.3.3",
     "can-dom-mutate": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "can-define": "^2.0.0",
     "can-event-dom-enter": "^2.0.0",
     "can-globals": "^1.0.0",
-    "can-test-helpers": "^1.1.1",
+    "can-test-helpers": "^1.1.4",
     "can-vdom": "^4.0.0",
     "can-view-nodelist": "^4.0.0",
     "detect-cyclic-packages": "^1.1.0",

--- a/test/colon/view-model-test.js
+++ b/test/colon/view-model-test.js
@@ -864,8 +864,8 @@ testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, 
 	canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding child-side (initializing view model)", function(assert) {
 		assert.expect(2);
 		var teardown = canTestHelpers.dev.willWarn(
-			"can-stache-bindings: The child of the sticky two-way binding <my-child>.name.first is changing or converting its value when set.  " +
-				"Conversions should only be done on the binding parent to preserve synchronization.  " +
+			"can-bind: The child of the sticky two-way binding <my-child name.first:bind=\"name\"> is changing or converting its value when set. " +
+				"Conversions should only be done on the binding parent to preserve synchronization. " +
 				"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
 			function(text, match) {
 				if(match) {

--- a/test/colon/view-model-test.js
+++ b/test/colon/view-model-test.js
@@ -287,7 +287,7 @@ testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, 
 		assert.expect(1);
 		var VM = SimpleMap.extend({
 			attr: function(prop, val){
-				if(prop === "bar") {
+				if(arguments.length > 1 && prop === "bar") {
 					assert.equal(val, "BAR");
 				}
 				return SimpleMap.prototype.attr.apply(this, arguments);
@@ -859,5 +859,36 @@ testHelpers.makeTests("can-stache-bindings - colon - ViewModel", function(name, 
 
 		assert.equal(parentVM.get('name'), 'child-updated', 'parent vm has correct value');
 		assert.equal(nestedValue.get('first'), 'child-updated', 'child vm has correct value');
+	});
+
+	canTestHelpers.dev.devOnlyTest("warn when changing the value of a sticky binding child-side (initializing view model)", function(assert) {
+		assert.expect(2);
+		var teardown = canTestHelpers.dev.willWarn(
+			"can-stache-bindings: The child of the sticky two-way binding <my-child>.name.first is changing or converting its value when set.  " +
+				"Conversions should only be done on the binding parent to preserve synchronization.  " +
+				"See https://canjs.com/doc/can-stache-bindings.html#StickyBindings for more about sticky bindings",
+			function(text, match) {
+				if(match) {
+					assert.ok(true, "Correct warning generated");
+				}
+			}
+		);
+
+		var childVM = new SimpleMap({
+			name: {
+				first: "Matt"
+			}
+		});
+		MockComponent.extend({
+			tag: "my-child",
+			viewModel: childVM,
+			template: stache('<input value:bind="name.first" />')
+		});
+		var parentVM = new SimpleMap({
+			name: 'Justin'	
+		});
+		stache('<my-child name.first:bind="name" /><input value:bind="name" />')(parentVM);
+
+		assert.equal(teardown(), 1, "Warning generated only once");
 	});
 });


### PR DESCRIPTION
Closes #487 -- it's not a fix for the problem as described, but will indicate to users that they're not working within the limitations of sticky two-way bindings.

In other words, when making a two way binding, ensure that only the parent side does type conversions or other modifications. Otherwise, the parent and child will not be bound together on init.