### PR TITLE
preventing events like on:click from creating viewmodels on normal elements

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -49,7 +49,8 @@ var onMatchStr = "on:",
 	viewModelBindingStr = "viewModel",
 	attributeBindingStr = "attribute",
 	scopeBindingStr = "scope",
-	viewModelOrAttributeBindingStr = "viewModelOrAttribute";
+	viewModelOrAttributeBindingStr = "viewModelOrAttribute",
+	viewModelSymbol = canSymbol.for("can.viewModel");
 
 var throwOnlyOneTypeOfBindingError = function() {
 	throw new Error("can-stache-bindings - you can not have contextual bindings ( this:from='value' ) and key bindings ( prop:from='value' ) on one element.");
@@ -92,7 +93,7 @@ var checkBindingState = function(bindingState, siblingBindingData) {
 
 var getEventBindingData = function (attributeName, el, scope) {
 	var bindingCode = attributeName.substr(onMatchStr.length);
-	var viewModel = el && el[canSymbol.for('can.viewModel')];
+	var viewModel = el && el[viewModelSymbol];
 	var elUsed = startsWith.call(bindingCode, elMatchStr);
 	var vmUsed = startsWith.call(bindingCode, vmMatchStr);
 	var byUsed = bindingCode.indexOf(byMatchStr) > -1;
@@ -529,7 +530,7 @@ var behaviors = {
 			if(process.env.NODE_ENV !== "production") {
 				if(
 					!eventBindingData.bindingCode &&
-					el[canSymbol.for("can.viewModel")] &&
+					el[viewModelSymbol] &&
 					("on" + event) in el
 				) {
 					dev.warn(
@@ -551,7 +552,7 @@ var behaviors = {
 				return;
 			}
 
-			var viewModel = canViewModel(el);
+			var viewModel = el[viewModelSymbol];
 
 			// expression.parse will read the attribute
 			// value and parse it identically to how mustache helpers
@@ -674,7 +675,7 @@ bindings.set(/on:[\w\.:]+/, behaviors.event);
 var getObservableFrom = {
 	// ### getObservableFrom.viewModelOrAttribute
 	viewModelOrAttribute: function(bindingData, bindingContext) {
-		var viewModel = bindingContext.element[canSymbol.for('can.viewModel')];
+		var viewModel = bindingContext.element[viewModelSymbol];
 
 		// if we have a viewModel, use it; otherwise, setup attribute binding
 		if (viewModel) {

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -729,4 +729,20 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 		assert.equal(teardown(), 1, 'warning shown');
 	});
 
+	QUnit.test("events should not create viewmodels (#540)", function(assert) {
+		var ta = this.fixture;
+
+		var template = stache("<div id='click-me' on:click='func()'></div>");
+		var frag = template({
+			func: function(){
+				assert.ok(true, "func ran");
+			}
+		});
+
+		ta.appendChild(frag);
+		var el = doc.getElementById("click-me");
+		domEvents.dispatch(el, "click");
+
+		assert.equal(el[canSymbol.for("can.viewModel")], undefined, "el does not have a viewmodel");
+	});
 });


### PR DESCRIPTION
This checks the `can.viewModel` symbol instead of using `can-view-model` so that ViewModels are not created on normal DOM elements when events happen. This also caches the Symbol everywhere it's used.

closes https://github.com/canjs/can-stache-bindings/issues/540.