### PR TITLE
Input string explanation

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -49,5 +49,6 @@
 	"mootools": true,
 	"browser": true,
 	"phantom": true,
-	"node": true
+	"node": true,
+	"esversion": 6
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js: node
+cache:
+  npm: false
 addons:
   firefox: latest
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js: node
-cache:
-  npm: false
 addons:
   firefox: latest
 dist: xenial

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -439,7 +439,26 @@ var behaviors = {
 		}
 		//!steal-remove-end
 
-		dataBinding.binding.start();
+		// Flag to prevent start binding twice in dev mode
+		var started = false;
+
+		//!steal-remove-start
+		if (process.env.NODE_ENV !== 'production') {
+			try {
+				started = true;
+				dataBinding.binding.start();
+			} catch (e) {
+				if (el.nodeName === 'INPUT') {
+					throw new Error('<input> elements always set properties to Strings, use string-to-any converter to get the right value type: (' + dataBinding.siblingBindingData.bindingAttributeName + '="string-to-any(' + dataBinding.siblingBindingData.parent.name + ')")');
+				}
+			}
+		}
+		//!steal-remove-end
+
+		if (!started) {
+			started = true;
+			dataBinding.binding.start();
+		}
 
 		var attributeListener = function(ev) {
 			var attrName = ev.attributeName,

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -444,20 +444,20 @@ var behaviors = {
 
 		//!steal-remove-start
 		if (process.env.NODE_ENV !== 'production') {
-			try {
-				started = true;
-				dataBinding.binding.start();
-			} catch (e) {
-				if (el.nodeName === 'INPUT') {
-					throw new Error('<input> elements always set properties to Strings, use string-to-any converter to get the right value type: (' + dataBinding.siblingBindingData.bindingAttributeName + '="string-to-any(' + dataBinding.siblingBindingData.parent.name + ')")');
+			if (el.nodeName === 'INPUT') {
+				try {
+					dataBinding.binding.start();
+					started = true;
+				} catch (error) {
+					throw new Error('<input> elements always set properties to Strings. ' + error.message);
 				}
 			}
 		}
 		//!steal-remove-end
 
 		if (!started) {
-			started = true;
 			dataBinding.binding.start();
+			started = true;
 		}
 
 		var attributeListener = function(ev) {

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -449,7 +449,7 @@ var behaviors = {
 					dataBinding.binding.start();
 					started = true;
 				} catch (error) {
-					throw new Error('<input> elements always set properties to Strings. ' + error.message);
+					throw new Error(error.message + ' <input> elements always set properties to Strings.');
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "can-define": "^2.0.0",
     "can-event-dom-enter": "^2.0.0",
     "can-globals": "^1.0.0",
+    "can-observable-object": "^1.0.1",
     "can-simple-dom": "^1.7.0",
     "can-test-helpers": "^1.1.4",
     "can-vdom": "^4.0.0",

--- a/test/data/tests.js
+++ b/test/data/tests.js
@@ -10,6 +10,8 @@ var globals = require('can-globals');
 var ObservableObject = require('can-observable-object');
 var canTestHelpers = require('can-test-helpers');
 
+var devOnlyTest = steal.isEnv("production") ? QUnit.skip : QUnit.test;
+
 stache.addBindings(stacheBindings);
 
 testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO, testIfRealDocument){
@@ -115,7 +117,29 @@ testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO
 		domMutateNode.removeChild.call(d, d.documentElement);
 	});
 
-	canTestHelpers.dev.devOnlyTest('Explain that <input> elements always set properties to Strings', function(assert) {
+	// canTestHelpers.dev.devOnlyTest('Explain that <input> elements always set properties to Strings', function(assert) {
+	// 	assert.expect(1);
+	// 	class Foo extends ObservableObject {
+	// 		static get props() {
+	// 			return {
+	// 				num: Number
+	// 			};
+	// 		}
+	// 	}
+
+	// 	try {
+	// 		stache('<input type="text" value:bind="this.num">')(new Foo());
+	// 		assert.ok(true);
+	// 	}
+	// 	catch (e) {
+	// 		assert.ok(true, e.message);
+	// 	}
+	// });
+});
+
+testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO, devOnlyTest){
+	devOnlyTest('Explain that <input> elements always set properties to Strings', function(assert) {
+		assert.expect(1);
 		class Foo extends ObservableObject {
 			static get props() {
 				return {
@@ -124,13 +148,12 @@ testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO
 			}
 		}
 
-		var template = stache('<input type="text" value:bind="this.num">');
-		var viewModel = new Foo();
-
 		try {
-			template(viewModel);
-		} catch (error) {
-			assert.equal(error.message, '<input> elements always set properties to Strings, use string-to-any converter to get the right value type: (value:bind="string-to-any(this.num)")');
+			stache('<input type="text" value:bind="this.num">')(new Foo());
+			assert.ok(true);
+		}
+		catch (e) {
+			assert.equal(e.message, '<input> elements always set properties to Strings.  is not of type Number. Property num is using "type: Number". Use "num: type.convert(Number)" to automatically convert values to Numbers when setting the "num" property.');
 		}
 	});
 });

--- a/test/data/tests.js
+++ b/test/data/tests.js
@@ -131,7 +131,7 @@ testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO
 			assert.ok(true);
 		}
 		catch (e) {
-			assert.equal(e.message, '<input> elements always set properties to Strings.  is not of type Number. Property num is using "type: Number". Use "num: type.convert(Number)" to automatically convert values to Numbers when setting the "num" property.');
+			assert.equal(e.message, '"" (string) is not of type Number. Property num is using "type: Number". Use "num: type.convert(Number)" to automatically convert values to Numbers when setting the "num" property. <input> elements always set properties to Strings.');
 		}
 	});
 });

--- a/test/data/tests.js
+++ b/test/data/tests.js
@@ -7,6 +7,8 @@ var SimpleMap = require("can-simple-map");
 var domMutate = require('can-dom-mutate');
 var domMutateNode = require('can-dom-mutate/node');
 var globals = require('can-globals');
+var ObservableObject = require('can-observable-object');
+var canTestHelpers = require('can-test-helpers');
 
 stache.addBindings(stacheBindings);
 
@@ -111,5 +113,24 @@ testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO
 		});
 
 		domMutateNode.removeChild.call(d, d.documentElement);
+	});
+
+	canTestHelpers.dev.devOnlyTest('Explain that <input> elements always set properties to Strings', function(assert) {
+		class Foo extends ObservableObject {
+			static get props() {
+				return {
+					num: Number
+				};
+			}
+		}
+
+		var template = stache('<input type="text" value:bind="this.num">');
+		var viewModel = new Foo();
+
+		try {
+			template(viewModel);
+		} catch (error) {
+			assert.equal(error.message, '<input> elements always set properties to Strings, use string-to-any converter to get the right value type: (value:bind="string-to-any(this.num)")');
+		}
 	});
 });

--- a/test/data/tests.js
+++ b/test/data/tests.js
@@ -8,9 +8,6 @@ var domMutate = require('can-dom-mutate');
 var domMutateNode = require('can-dom-mutate/node');
 var globals = require('can-globals');
 var ObservableObject = require('can-observable-object');
-var canTestHelpers = require('can-test-helpers');
-
-var devOnlyTest = steal.isEnv("production") ? QUnit.skip : QUnit.test;
 
 stache.addBindings(stacheBindings);
 
@@ -116,25 +113,6 @@ testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO
 
 		domMutateNode.removeChild.call(d, d.documentElement);
 	});
-
-	// canTestHelpers.dev.devOnlyTest('Explain that <input> elements always set properties to Strings', function(assert) {
-	// 	assert.expect(1);
-	// 	class Foo extends ObservableObject {
-	// 		static get props() {
-	// 			return {
-	// 				num: Number
-	// 			};
-	// 		}
-	// 	}
-
-	// 	try {
-	// 		stache('<input type="text" value:bind="this.num">')(new Foo());
-	// 		assert.ok(true);
-	// 	}
-	// 	catch (e) {
-	// 		assert.ok(true, e.message);
-	// 	}
-	// });
 });
 
 testHelpers.makeTests("can-stache-bindings - data", function(name, doc, enableMO, devOnlyTest){

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -59,7 +59,6 @@ var helpers = {
 	},
 	makeTests: function(name, makeTest) {
 		var noop = function(){};
-
 		helpers.makeQUnitModule(name+" - dom", document, true);
 		makeTest(name+" - dom", document, true, QUnit.test, noop);
 		makeTest(name+" - dom - dev only", document, true, noop, canTestHelpers.dev.devOnlyTest);


### PR DESCRIPTION
For https://github.com/canjs/canjs/issues/5310

This adds an error message to explain that `<input>` setting a property as a string and advice to use `string-to-any` converter :

`<input> elements always set properties to Strings, use string-to-any converter to get the right value type: (value:bind="string-to-any(this.num)")`