### PR TITLE
Explain why unable to bind

### DIFF
--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -642,7 +642,17 @@ var behaviors = {
 			};
 			canReflect.onValue(bindingContextObservable, updateListener);
 		} else {
-			canEventQueue.on.call(bindingContext, event, handler);
+			try {
+				canEventQueue.on.call(bindingContext, event, handler);
+			} catch (error) {
+				var msg = 'can-stache-bindings - Unable to bind "' + event + '"';
+				msg += ': ';
+				msg += '"complete" is a property on a plain object: ';
+				msg += JSON.stringify(bindingContext);
+				msg += '. Bindning is available with observable objects only.';
+				msg += ' For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_';
+				throw new Error(msg);
+			}
 		}
 	}
 };

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -645,11 +645,9 @@ var behaviors = {
 			try {
 				canEventQueue.on.call(bindingContext, event, handler);
 			} catch (error) {
-				var keys = Object.keys(bindingContext);
-				var prop = keys[0];
 				if (/Unable to bind/.test(error.message)) {
 					var msg = 'can-stache-bindings - Unable to bind "' + event + '"';
-					msg += ': "' + prop  + '" is a property on a plain object "';
+					msg += ': "' + event  + '" is a property on a plain object "';
 					msg += JSON.stringify(bindingContext);
 					msg += '". Binding is available with observable objects only.';
 					msg += ' For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_';

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -645,12 +645,18 @@ var behaviors = {
 			try {
 				canEventQueue.on.call(bindingContext, event, handler);
 			} catch (error) {
-				var msg = 'can-stache-bindings - Unable to bind "' + event + '"';
-				msg += ': "complete" is a property on a plain object "';
-				msg += JSON.stringify(bindingContext);
-				msg += '". Bindning is available with observable objects only.';
-				msg += ' For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_';
-				throw new Error(msg);
+				var keys = Object.keys(bindingContext);
+				var prop = keys[0];
+				if (/Unable to bind/.test(error.message)) {
+					var msg = 'can-stache-bindings - Unable to bind "' + event + '"';
+					msg += ': "' + prop  + '" is a property on a plain object "';
+					msg += JSON.stringify(bindingContext);
+					msg += '". Binding is available with observable objects only.';
+					msg += ' For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_';
+					throw new Error(msg);
+				} else {
+					throw error;
+				}
 			}
 		}
 	}

--- a/can-stache-bindings.js
+++ b/can-stache-bindings.js
@@ -646,10 +646,9 @@ var behaviors = {
 				canEventQueue.on.call(bindingContext, event, handler);
 			} catch (error) {
 				var msg = 'can-stache-bindings - Unable to bind "' + event + '"';
-				msg += ': ';
-				msg += '"complete" is a property on a plain object: ';
+				msg += ': "complete" is a property on a plain object "';
 				msg += JSON.stringify(bindingContext);
-				msg += '. Bindning is available with observable objects only.';
+				msg += '". Bindning is available with observable objects only.';
 				msg += ' For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_';
 				throw new Error(msg);
 			}

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -779,7 +779,7 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 		try {
 			template(vm);
 		} catch (error) {
-			assert.equal(error.message, 'can-stache-bindings - Unable to bind "complete": "complete" is a property on a plain object "{"complete":false}". Bindning is available with observable objects only. For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_');
+			assert.equal(error.message, 'can-stache-bindings - Unable to bind "complete": "complete" is a property on a plain object "{"complete":false}". Binding is available with observable objects only. For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_');
 		}
 	});
 });

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -779,7 +779,7 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 		try {
 			template(vm);
 		} catch (error) {
-			assert.equal(error.message, 'can-stache-bindings - Unable to bind "complete": "complete" is a property on a plain object: {"complete":false}. Bindning is available with observable objects only. For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_');
+			assert.equal(error.message, 'can-stache-bindings - Unable to bind "complete": "complete" is a property on a plain object "{"complete":false}". Bindning is available with observable objects only. For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_');
 		}
 	});
 });

--- a/test/colon/event-test.js
+++ b/test/colon/event-test.js
@@ -767,4 +767,19 @@ testHelpers.makeTests("can-stache-bindings - colon - event", function(name, doc,
 
 		assert.equal(el[canSymbol.for("can.viewModel")], undefined, "el does not have a viewmodel");
 	});
+
+	QUnit.test("Improve error message when unable to bind", function(assert) {
+		var vm = new SimpleMap({
+			todo: {
+				complete: false
+			}
+		});
+		vm.handle = function() {} ;
+		var template = stache('<div on:complete:by:todo="handle()"></div>');
+		try {
+			template(vm);
+		} catch (error) {
+			assert.equal(error.message, 'can-stache-bindings - Unable to bind "complete": "complete" is a property on a plain object: {"complete":false}. Bindning is available with observable objects only. For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_');
+		}
+	});
 });


### PR DESCRIPTION
Fixes #542 

This catchs the `unable to bind` error from `can-event-queue` and explain why it is thrown, for example, with:
```js
var vm = new SimpleMap({
    todo: {
        complete: false
    }
});
vm.handle = function() {} ;
var template = stache('<div on:complete:by:todo="handle()"></div>');
// can-stache-bindings - Unable to bind "complete": "complete" is a property on a plain object: {"complete":false}. Bindning is available with observable objects only. For more details check https://canjs.com/doc/can-stache-bindings.html#Callafunctionwhenaneventhappensonavalueinthescope_animation_
```